### PR TITLE
chore: open-source readiness prep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo.
+# These users are requested for review on every pull request.
+* @johnrufusone @banuakman

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -24,12 +24,8 @@ other community space), you agree to uphold that standard.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainers. Reports can be filed privately via GitHub's
-**"Report content"** feature, or by contacting the maintainers at the address
-listed in this repository's profile.
-
-> Maintainers: replace this line with a dedicated conduct contact
-> (e.g. `conduct@yourdomain`) before launch.
+reported privately to the project maintainers via GitHub's **"Report content"**
+feature (available from the `...` menu on any comment, issue, or pull request).
 
 All complaints will be reviewed and investigated promptly and fairly. Project
 maintainers are obligated to respect the privacy and security of the reporter of

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Python backend (uv / pip-compatible)
+  - package-ecosystem: "pip"
+    directory: "/packages/core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  # Next.js web UI
+  - package-ecosystem: "npm"
+    directory: "/packages/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-06-30
+
+Initial public release.
+
+### Added
+- Multi-agent "Executive" system: a single coherent executive persona backed by
+  eight specialist sub-agents, powered by the Anthropic Claude API.
+- Python backend (`packages/core`) — FastAPI service, orchestrator, specialist
+  agents, ChromaDB-backed RAG, CLI, and prompt-caching layer.
+- Next.js 15 web UI (`packages/ui`), including the static `/architecture` page.
+- Curated MBA knowledge base (`knowledge/`) and eval suite (`evals/`).
+- Optional integrations: Slack, Discord, and email.
+- Docker and Fly.io deployment configuration.
+- Open-source project setup: Apache-2.0 license, contribution guide, code of
+  conduct, security policy, issue/PR templates, and CI.
+
+[Unreleased]: https://github.com/SenteLabsAI/OpenExecutive/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/SenteLabsAI/OpenExecutive/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Open Executive
 
+[![CI](https://github.com/SenteLabsAI/OpenExecutive/actions/workflows/ci.yml/badge.svg)](https://github.com/SenteLabsAI/OpenExecutive/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Next.js 15](https://img.shields.io/badge/Next.js-15-black.svg)](https://nextjs.org/)
+
 An AI system that acts as your company's virtual executive team — a senior advisor with Harvard MBA-level knowledge, customized for your specific business.
 
 ## What It Does

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,11 +16,8 @@ Instead, use GitHub's private vulnerability reporting:
 1. Go to the repository's **Security** tab.
 2. Click **"Report a vulnerability"** to open a private advisory.
 
-If you cannot use private reporting, contact the maintainers at the security
-address listed in the repository profile.
-
-> Maintainers: replace this line with a dedicated security contact
-> (e.g. `security@yourdomain`) before launch.
+This routes your report privately to the maintainers. Please use this channel
+rather than email so reports are tracked and not missed.
 
 Please include:
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -5,6 +5,7 @@ description = "AI-powered virtual executive team"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "Apache-2.0"}
+authors = [{name = "Open Executive Contributors"}]
 dependencies = [
     "anthropic>=0.52.0",
     "fastapi>=0.111.0",
@@ -32,6 +33,11 @@ dependencies = [
     "defusedxml>=0.7.1",
     "feedparser>=6.0.11",
 ]
+
+[project.urls]
+Homepage = "https://github.com/SenteLabsAI/OpenExecutive"
+Repository = "https://github.com/SenteLabsAI/OpenExecutive"
+Issues = "https://github.com/SenteLabsAI/OpenExecutive/issues"
 
 [project.optional-dependencies]
 dev = [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,14 @@
   "name": "open-executive-ui",
   "version": "0.1.0",
   "private": true,
+  "description": "Next.js 15 web UI for Open Executive — an AI-powered virtual executive team.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SenteLabsAI/OpenExecutive.git",
+    "directory": "packages/ui"
+  },
+  "homepage": "https://github.com/SenteLabsAI/OpenExecutive#readme",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## What & why

Prepares the repo to be made **public** as a proper open-source project. The repo already had a strong baseline (Apache-2.0 LICENSE, README, CONTRIBUTING, SECURITY, Code of Conduct, PR/issue templates, CI), so this is **polish + metadata**, not a rebuild.

A pre-flight secret/data scan came back clean (single-commit history, no keys, no `.env`, no `company/` data, comprehensive `.gitignore`).

## Changes

- **Contacts → GitHub private reporting only.** Removed the placeholder `replace this line / yourdomain` maintainer-contact lines from `SECURITY.md` and `.github/CODE_OF_CONDUCT.md`. Vulnerability reports route through the Security tab's "Report a vulnerability"; conduct reports through GitHub's "Report content" feature. No personal email exposed.
- **Package metadata.** Added `description`/`license`/`repository`/`homepage` to `packages/ui/package.json`, and `authors` + `[project.urls]` (Homepage/Repository/Issues) to `packages/core/pyproject.toml`.
- **CHANGELOG.md** — Keep a Changelog format with an initial `0.1.0` entry.
- **.github/dependabot.yml** — weekly updates for `pip` (`/packages/core`), `npm` (`/packages/ui`), and `github-actions` (`/`).
- **.github/CODEOWNERS** — `@johnrufusone @banuakman`.
- **README badges** — CI, Apache-2.0 license, Python 3.11+, Next.js 15.

Docs/metadata only — no source or runtime behavior changes.

## Verification

- `packages/ui/package.json` parses as valid JSON.
- `packages/core/pyproject.toml` rebuilt successfully via `uv` (urls + authors present).
- `.github/dependabot.yml` parses as valid YAML (version 2, 3 ecosystems).
- No placeholder text, stubs, or secrets remain in the diff.
- Adversarial review (anvil-security-reviewer): **PASS** — all URLs, handles, badge targets, and dependabot paths verified.

## Follow-up (not in this PR)

After merge: flip repo to public, set description/homepage/topics, enable forking, add branch protection on `main`, enable Discussions + Dependabot alerts + secret scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)