### PR TITLE
docs: add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 An AI system that acts as your company's virtual executive team — a senior advisor with Harvard MBA-level knowledge, customized for your specific business.
 
+## Demo
+
+[![Open Executive demo video](https://img.youtube.com/vi/HqbiU1-oSWs/maxresdefault.jpg)](https://youtu.be/HqbiU1-oSWs)
+
+A walkthrough of Open Executive in action — [watch on YouTube](https://youtu.be/HqbiU1-oSWs).
+
 ## What It Does
 
 Developed by [sentelabs.ai](https://sentelabs.ai) Open Executive provides a single coherent executive voice backed by eight specialist AI agents:


### PR DESCRIPTION
## What & why

Adds a **Demo** section to the README with the Open Executive walkthrough video, so first-time visitors can see the product in action before reading the architecture and setup sections.

## How it works

- New `## Demo` section sits directly below the intro paragraph and above `## What It Does` — the first thing after the badges and one-liner.
- The video is embedded the way GitHub supports it: a YouTube thumbnail image (`https://img.youtube.com/vi/HqbiU1-oSWs/maxresdefault.jpg`, verified to return 200) wrapped in a link to the video, plus a plain-text "watch on YouTube" link for anyone whose client blocks the image.
- The link uses the clean `https://youtu.be/HqbiU1-oSWs` form with the share tracking parameter stripped.

README-only change; no code, tests, or architecture docs are affected.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [ ] Tests added/updated for new behavior (`pytest packages/core/tests/unit/`) — n/a, docs only
- [ ] `ruff check` and `mypy` pass (`make lint`) — n/a, no Python touched
- [ ] UI builds if touched (`cd packages/ui && npx tsc --noEmit`) — n/a, UI untouched
- [ ] Eval scenarios added for a new agent or prompt change (if applicable) — n/a
- [x] Architecture docs updated if a documented topic changed — no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Worth confirming the video link points at the intended recording and that the thumbnail renders as expected on the rendered README.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K15jDyXR9732ZbdkscwCAh)_