### PR TITLE
docs: correct README demo video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ An AI system that acts as your company's virtual executive team — a senior adv
 
 ## Demo
 
-[![Open Executive demo video](https://img.youtube.com/vi/HqbiU1-oSWs/maxresdefault.jpg)](https://youtu.be/HqbiU1-oSWs)
+[![Open Executive demo video](https://img.youtube.com/vi/O_g97xxVTMk/maxresdefault.jpg)](https://youtu.be/O_g97xxVTMk)
 
-A walkthrough of Open Executive in action — [watch on YouTube](https://youtu.be/HqbiU1-oSWs).
+A walkthrough of Open Executive in action — [watch on YouTube](https://youtu.be/O_g97xxVTMk).
 
 ## What It Does
 


### PR DESCRIPTION
## What & why

The Demo section added in [#29](https://github.com/SenteLabsAI/OpenExecutive/pull/29) pointed at the wrong recording. This swaps it for the intended walkthrough video.

## How it works

- Replaces video id `HqbiU1-oSWs` with `O_g97xxVTMk` in both places it appears: the clickable thumbnail image and the text "watch on YouTube" link.
- Thumbnail URL `https://img.youtube.com/vi/O_g97xxVTMk/maxresdefault.jpg` verified to return 200.
- The link uses the clean `https://youtu.be/O_g97xxVTMk` form — the `&t=22s` start-offset from the shared URL is dropped so the video plays from the beginning.

Two lines in `README.md`; nothing else touched.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [ ] Tests added/updated for new behavior (`pytest packages/core/tests/unit/`) — n/a, docs only
- [ ] `ruff check` and `mypy` pass (`make lint`) — n/a, no Python touched
- [ ] UI builds if touched (`cd packages/ui && npx tsc --noEmit`) — n/a, UI untouched
- [ ] Eval scenarios added for a new agent or prompt change (if applicable) — n/a
- [x] Architecture docs updated if a documented topic changed — no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Please confirm `O_g97xxVTMk` is the right recording this time, and say the word if you'd rather the link keep the 22-second start offset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K15jDyXR9732ZbdkscwCAh)_