### PR TITLE
docs: require completed PR template and sync CONTRIBUTING architecture-docs procedure

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,6 +24,10 @@ All PRs must:
 3. Include tests for new behavior
 4. For new or modified agents: include at least 2 eval scenarios
 5. **Architecture docs**: verify `/architecture` reflects your change (see below)
+6. **A completed PR description using the template** — what changed, why, and
+   how it works, with the checklist filled in. PRs submitted with an empty
+   template will be closed; you're welcome to resubmit with the sections
+   completed.
 
 ## Adding a New Specialist Agent
 
@@ -41,21 +45,36 @@ Requirements:
 
 ## Architecture Docs (`/architecture` page)
 
-The `/architecture` page in the UI documents the system for the team. Parts of it are live (auto-pulled from the API) and parts are static diagrams.
+The `/architecture` page in the UI is served from **static, hand-authored
+content**: one `packages/core/openexecutive/architecture/prebuilt/<section_id>.json`
+file per section listed in `architecture/sections.py`. Nothing on that path
+calls an LLM at runtime, so nothing updates itself — if your PR changes
+behavior a section describes and you don't re-author the section, the page
+silently goes stale.
 
-**You do NOT need to update anything if you:**
-- Add a new specialist agent (the Agent Council section pulls from `GET /agents` automatically)
-- Add or change an API endpoint (the API Reference pulls from `GET /openapi.json` automatically)
-- Add or change a workflow (the Workflows section pulls from `GET /workflows` automatically)
+The deep source-of-truth notes behind the page live in
+`packages/core/openexecutive/architecture/architecture-facts.yaml`.
 
-**You DO need to update the static diagrams in `packages/ui/src/app/architecture/page.tsx` if you:**
-- Change the overall request flow (how requests move from client → API → Executive → specialists → response)
-- Change the prompt caching strategy (how system blocks are built or what's in the user turn)
-- Add a new integration layer (new inbound channel, new external service)
-- Change the memory system architecture (new storage backend, new extraction pipeline)
-- Change how the knowledge/RAG pipeline works at a structural level
+**When your PR materially changes a documented topic, update BOTH in the same
+PR**: the relevant `architecture-facts.yaml` key, and the affected
+`prebuilt/<section_id>.json`. This applies equally to *changes* under an
+existing topic (e.g. adding a new integration channel, changing a documented
+endpoint's response shape) — not just brand-new topics. The topic → section-id
+map and full procedure are in [CLAUDE.md](../CLAUDE.md#architecture-docs);
+common cases:
 
-These structural changes are rare and significant — they warrant a diagram update in the same PR.
+- New or changed integration channel → `integrations`
+- New workflow primitive or routing pattern → `workflows` / `agents` / `lifecycle`
+- Cache layout change → `caching`
+- Endpoint added/removed/renamed or response shape changed → `api`
+- New top-level module under `packages/core/openexecutive/` → new `SectionSpec`
+  in `architecture/sections.py`, matching entry in
+  `packages/ui/src/app/architecture/page.tsx`, and a new `prebuilt/<id>.json`
+
+Each `prebuilt/<id>.json` carries `section_id`, `title`, `markdown`, `mermaid`
+(string or `null`), and `generated_at`; validate edits with
+`python -m json.tool`. Pure additions to `SPECIALIST_REGISTRY` are
+auto-reflected in the `agents` facts and need no YAML edit.
 
 ## Prompt Changes
 


### PR DESCRIPTION
## What & why

Two external feature PRs (#39, #40) arrived today with the PR template submitted completely empty — no "What & why", no "How it works", no checklist. When we went to cite the requirement, it turned out `.github/CONTRIBUTING.md` never actually states that a written description is required; only the template's HTML comment implies it. Both PRs were closed with an invitation to resubmit; this PR closes the documentation gap so the requirement is citable next time.

While in the file: the **Architecture Docs section was stale** — it still described the retired live-pulling `/architecture` page ("pulls from `GET /agents` automatically", "update the static diagrams in `page.tsx`"), while the actual procedure (per `CLAUDE.md`) is static `prebuilt/<section_id>.json` files plus `architecture-facts.yaml`, re-authored in the same PR whenever a documented topic changes. That stale guidance is arguably why #40 shipped a new integration with no `integrations` docs update — the doc contributors read pointed them at the wrong procedure.

## How it works

- **§ PR Requirements** gains item 6: a completed PR description using the template (what changed, why, how it works, checklist filled in); empty-template PRs are closed and may be resubmitted.
- **§ Architecture Docs** is rewritten to match the current `CLAUDE.md` procedure: static hand-authored `prebuilt/<section_id>.json` per section, `architecture-facts.yaml` as source-of-truth notes, both updated in the same PR when a documented topic changes (including changes under existing topics), with the common topic → section-id cases listed and a link to the full map in `CLAUDE.md`.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders (docs-only)
- [x] Tests added/updated for new behavior (n/a — documentation change)
- [x] `ruff check` and `mypy` pass (no Python touched)
- [x] UI builds if touched (no UI touched)
- [x] Eval scenarios added for a new agent or prompt change (n/a)
- [x] Architecture docs updated if a documented topic changed (n/a — this PR documents the procedure itself)
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

The new rule is deliberately phrased as "closed, welcome to resubmit" — matching how #39/#40 were handled — rather than leaving PRs open indefinitely awaiting a description.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bk8kESP7i3oMFZC8d9vSHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk8kESP7i3oMFZC8d9vSHg)_