### PR TITLE
fix: fresh clone from .env.example can boot locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,10 +147,14 @@ TELEGRAM_WEBHOOK_SECRET=     # any random string; set when registering the webho
 # Setup: create an application at https://discord.com/developers/applications
 # Enable the "Message Content" privileged intent. Invite with bot + applications.commands scopes.
 # Run: make discord  (in a second shell alongside make dev)
-DISCORD_BOT_TOKEN=           # Bot token from the Discord Developer Portal → Bot tab
-DISCORD_APP_ID=              # Application ID (General Information tab)
-DISCORD_GUILD_IDS=           # comma-separated guild (server) IDs for instant slash-command registration during dev; leave blank for global
-DISCORD_NOTIFY_CHANNEL_ID=   # default channel ID for outbound notifications/alerts (optional)
+# Bot token from the Discord Developer Portal → Bot tab
+DISCORD_BOT_TOKEN=
+# Application ID (General Information tab)
+DISCORD_APP_ID=
+# comma-separated guild (server) IDs for instant slash-command registration during dev; leave blank for global
+DISCORD_GUILD_IDS=
+# default channel ID for outbound notifications/alerts (optional)
+DISCORD_NOTIFY_CHANNEL_ID=
 DISCORD_THREAD_RESPONSE_GATE_ENABLED=true  # in bot-owned threads, ask Haiku whether each non-mention message warrants a reply (filters side chatter in multi-party threads); set to false to reply to every thread message
 
 # Google Chat integration (optional)
@@ -164,8 +168,11 @@ GOOGLE_CHAT_SERVICE_ACCOUNT_EMAIL=   # Option B: SA email for impersonation via 
 # Setup: https://github.com/taylorwilsdon/google_workspace_mcp
 # 1. Create OAuth Desktop credentials at console.cloud.google.com
 #    Enable: Gmail API, Google Calendar API, Google Drive API
-# 2. Set these two vars, then run: uvx workspace-mcp auth
-#    That opens a browser sign-in — authenticate as EXEC_EMAIL_ADDRESS.
+# 2. Set these two vars, then mint a token (workspace-mcp has no `auth`
+#    subcommand — OAuth fires on the first tool call):
+#      uv run --with mcp python scripts/mint-google-token.py
+#    Sign in as EXEC_EMAIL_ADDRESS. Credentials land in
+#    .gworkspace-credentials/ (gitignored).
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ coverage.xml
 # Company data — never commit
 packages/core/company/
 !packages/core/company/.gitkeep
+# Runtime profile/docs (COMPANY_PROFILE_PATH defaults to repo-root company/)
+company/
 
 # Vector store
 *.chroma/

--- a/packages/core/openexecutive/config.py
+++ b/packages/core/openexecutive/config.py
@@ -22,11 +22,27 @@ if not _FOUND_ENV:
 _ENV_FILE = _ROOT / ".env"
 
 
+def _blank_or_comment(v: Any) -> bool:
+    """True for unset, '', or a dotenv inline-comment captured as the value.
+
+    Optional keys are often left as `KEY=`. `make dev` exports those as
+    empty strings; an inline `# comment` on the same line can instead be
+    parsed as the value. Both must map to "unset".
+    """
+    return v is None or (
+        isinstance(v, str) and (not v.strip() or v.strip().startswith("#"))
+    )
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=str(_ENV_FILE),
         env_file_encoding="utf-8",
         extra="ignore",
+        # .env.example (and copies of it) leave optional keys as `KEY=`.
+        # `make dev` exports those as empty strings; without this flag an
+        # optional int like DISCORD_NOTIFY_CHANNEL_ID crashes startup.
+        env_ignore_empty=True,
     )
 
     # Optional: a deployment can run entirely on local / OpenRouter models
@@ -275,6 +291,13 @@ class Settings(BaseSettings):
         True, alias="DISCORD_THREAD_RESPONSE_GATE_ENABLED"
     )
 
+    @field_validator("discord_notify_channel_id", mode="before")
+    @classmethod
+    def _parse_notify_channel_id(cls, v: Any) -> Any:
+        if _blank_or_comment(v):
+            return None
+        return v
+
     # @mention auto-thread router. The default mode promotes nearly every
     # plain-channel @mention into a fresh auto-titled thread (with a
     # one-line pointer left behind in the channel) — except when the
@@ -308,7 +331,9 @@ class Settings(BaseSettings):
             return [int(x) for x in v]
         if isinstance(v, (int, float)):
             return [int(v)]
-        if isinstance(v, str) and v.strip():
+        if _blank_or_comment(v):
+            return []
+        if isinstance(v, str):
             return [int(x.strip()) for x in v.split(",") if x.strip()]
         return []
 

--- a/packages/core/tests/unit/test_config_lists.py
+++ b/packages/core/tests/unit/test_config_lists.py
@@ -23,14 +23,38 @@ def _required_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_discord_guild_ids_comma_string(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DISCORD_GUILD_IDS", "123,456")
-    assert Settings().discord_guild_ids == [123, 456]
+    assert Settings(_env_file=None).discord_guild_ids == [123, 456]
 
 
 def test_discord_guild_ids_single_value(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DISCORD_GUILD_IDS", "789")
-    assert Settings().discord_guild_ids == [789]
+    assert Settings(_env_file=None).discord_guild_ids == [789]
 
 
 def test_discord_guild_ids_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DISCORD_GUILD_IDS", "")
-    assert Settings().discord_guild_ids == []
+    assert Settings(_env_file=None).discord_guild_ids == []
+
+
+def test_discord_notify_channel_id_empty_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blank DISCORD_NOTIFY_CHANNEL_ID= in .env must not fail int parsing."""
+    monkeypatch.setenv("DISCORD_NOTIFY_CHANNEL_ID", "")
+    assert Settings(_env_file=None).discord_notify_channel_id is None
+
+
+def test_discord_notify_channel_id_inline_comment_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dotenv can capture `# comment` after `KEY=` as the value."""
+    monkeypatch.setenv(
+        "DISCORD_NOTIFY_CHANNEL_ID",
+        "# default channel ID for outbound notifications/alerts (optional)",
+    )
+    assert Settings(_env_file=None).discord_notify_channel_id is None
+
+
+def test_discord_notify_channel_id_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISCORD_NOTIFY_CHANNEL_ID", "123456789")
+    assert Settings(_env_file=None).discord_notify_channel_id == 123456789


### PR DESCRIPTION
## What & why

Copying `.env.example` and running `make dev` currently fails before the API starts: empty optional ints (`DISCORD_NOTIFY_CHANNEL_ID=`) are exported as `""` and pydantic refuses to parse them. The default company profile path is repo-root `company/`, which was not gitignored (only `packages/core/company/` was), so a local onboarding profile shows up as untracked. The example also still says `uvx workspace-mcp auth`, which current workspace-mcp rejects.

## How it works

- `Settings` now uses `env_ignore_empty=True` and treats blank or inline-comment values as unset for Discord channel/guild IDs.
- `.gitignore` ignores repo-root `company/` (profile, uploaded docs, MCP config).
- `.env.example` moves comments off empty Discord assignments so dotenv does not ingest `# comment` as the value, and points Workspace MCP setup at `scripts/mint-google-token.py`.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] Tests added/updated for new behavior (`pytest packages/core/tests/unit/`)
- [x] `ruff check` and `mypy` pass (`make lint`)
- [ ] UI builds if touched (`cd packages/ui && npx tsc --noEmit`)
- [x] Eval scenarios added for a new agent or prompt change (if applicable)
- [x] Architecture docs updated if a documented topic changed
      (see the "Architecture Docs" section in `CLAUDE.md`)
- [x] No secrets, credentials, or personal data committed

UI was not touched. Lint/tests run on the Settings unit tests + `ruff check` of the changed Python files; full `make lint` (mypy of the whole package) was not re-run in this PR.

## Notes for reviewers

Found while bringing up a local clone on Ollama with a copied `.env.example`. Discord is unused in that setup; the crash still happens because the blank keys are present. I did not change Auth.js `trustHost` — local sign-in can use `packages/ui/.env.local` with `AUTH_TRUST_HOST=true` instead.


Made with [Cursor](https://cursor.com)