### PR TITLE
chore(deps): tell dependabot to ignore mcp 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # mcp 2.x removed mcp.server.fastmcp (renamed to MCPServer), and the API
+    # image build resolves from pyproject.toml, so widening the <2 cap ships a
+    # boot crash. Keep dependabot on 1.x until the code migrates to the 2.x API.
+    ignore:
+      - dependency-name: "mcp"
+        versions: [">=2"]
     groups:
       python-dependencies:
         patterns:


### PR DESCRIPTION
## What & why

Dependabot proposed widening the mcp cap from `<2` to `<3` (#63). Merging that would reintroduce the boot crash the cap exists to prevent: mcp 2.x removed `mcp.server.fastmcp` (renamed to `MCPServer`), and the API image build resolves dependencies from `pyproject.toml`, so any image built with mcp 2.x in range fails on import at startup — the outage fixed by #55.

## How it works

Adds an `ignore` rule for `mcp >=2` to the pip ecosystem entry in `.github/dependabot.yml`, with a comment explaining why. Dependabot stops proposing 2.x/3.x range widenings but continues to propose 1.x bumps (like #57, which merged fine). Remove the rule when the code migrates to the 2.x `MCPServer` API.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] Tests added/updated for new behavior — config-only change; no testable runtime behavior
- [x] `ruff check` and `mypy` pass — no Python touched
- [x] UI builds if touched — no UI files touched
- [x] Eval scenarios added for a new agent or prompt change — not applicable
- [x] Architecture docs updated if a documented topic changed — no documented topic changed
- [x] No secrets, credentials, or personal data committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD)_