### PR TITLE
fix(io): pin UTF-8 on the slot/fixture save-restore file IO

### DIFF
--- a/packages/core/openexecutive/architecture/facts.py
+++ b/packages/core/openexecutive/architecture/facts.py
@@ -161,7 +161,7 @@ def _load_curated() -> dict[str, Any]:
     if not _FACTS_YAML.exists():
         return {}
     try:
-        with open(_FACTS_YAML) as f:
+        with open(_FACTS_YAML, encoding="utf-8") as f:
             loaded = yaml.safe_load(f) or {}
     except yaml.YAMLError as exc:
         # A corrupt or hand-edited YAML must not 500 the entire

--- a/packages/core/openexecutive/cli/fixture_loader.py
+++ b/packages/core/openexecutive/cli/fixture_loader.py
@@ -143,7 +143,7 @@ def _summarize_departments(path: Path) -> list[dict[str, Any]]:
     import yaml
 
     try:
-        data = yaml.safe_load(path.read_text()) or {}
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except Exception:
         return []
     out: list[dict[str, Any]] = []
@@ -162,7 +162,7 @@ def _summarize_people(path: Path) -> list[dict[str, Any]]:
     import yaml
 
     try:
-        data = yaml.safe_load(path.read_text()) or {}
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except Exception:
         return []
     out: list[dict[str, Any]] = []
@@ -295,7 +295,7 @@ async def _load_from_dir(
         # Record which fixture is active so the UI can show it and so a
         # subsequent load() knows not to take a fresh snapshot.
         sentinel.parent.mkdir(parents=True, exist_ok=True)
-        sentinel.write_text(fixture_name)
+        sentinel.write_text(fixture_name, encoding="utf-8")
 
         # Honcho workspace isolation: switch to a per-fixture workspace
         # so demo turns sync to a sacrificial store rather than polluting
@@ -861,7 +861,7 @@ def get_fixture_status(settings: Any) -> dict[str, Any]:
     active_fixture: str | None = None
     if sentinel.exists():
         try:
-            content = sentinel.read_text().strip()
+            content = sentinel.read_text(encoding="utf-8").strip()
             # Defence-in-depth: only return the value if it matches the same
             # allowlist used by /fixtures/{name}/load. Anything else (garbage,
             # hand-edit, tampering) is treated as "no fixture active".
@@ -985,7 +985,7 @@ def _dump_episodic_memory(memory_path: Path) -> dict[str, int]:
         "advice_given": advice,
         "scheduled_actions": [],
     }
-    memory_path.write_text(json.dumps(payload, indent=2, default=str))
+    memory_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
     return {
         "decisions": len(decisions),
         "initiatives": len(initiatives),
@@ -1031,7 +1031,7 @@ def _dump_people(people_path: Path) -> int:
 
     import yaml
 
-    people_path.write_text(yaml.safe_dump({"people": rows}, sort_keys=False))
+    people_path.write_text(yaml.safe_dump({"people": rows}, sort_keys=False), encoding="utf-8")
     return len(rows)
 
 
@@ -1083,7 +1083,7 @@ def _dump_departments(dept_path: Path) -> int:
 
     import yaml
 
-    dept_path.write_text(yaml.safe_dump({"departments": rows}, sort_keys=False))
+    dept_path.write_text(yaml.safe_dump({"departments": rows}, sort_keys=False), encoding="utf-8")
     return len(rows)
 
 
@@ -1100,7 +1100,7 @@ def _seed_episodic_memory(memory_path: Path, settings: Any) -> dict[str, int]:
         return dict(_empty)
 
     try:
-        data: dict[str, Any] = json.loads(memory_path.read_text())
+        data: dict[str, Any] = json.loads(memory_path.read_text(encoding="utf-8"))
     except Exception:
         return dict(_empty)
 
@@ -1300,7 +1300,7 @@ def _seed_people(people_path: Path) -> int:
     try:
         import yaml
 
-        data = yaml.safe_load(people_path.read_text()) or {}
+        data = yaml.safe_load(people_path.read_text(encoding="utf-8")) or {}
     except Exception:
         return 0
 
@@ -1397,7 +1397,7 @@ def _seed_departments(dept_path: Path) -> int:
     try:
         import yaml
 
-        data = yaml.safe_load(dept_path.read_text()) or {}
+        data = yaml.safe_load(dept_path.read_text(encoding="utf-8")) or {}
     except Exception:
         return 0
 

--- a/packages/core/openexecutive/clients/rotation.py
+++ b/packages/core/openexecutive/clients/rotation.py
@@ -125,7 +125,7 @@ async def run_client_rotation(
 
     marker = _rotation_marker(settings)
     marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text(datetime.now(UTC).isoformat())
+    marker.write_text(datetime.now(UTC).isoformat(), encoding="utf-8")
 
     rotated: list[str] = []
     failed: dict[str, str] = {}
@@ -213,7 +213,7 @@ async def _force_restore(
         slot = _require_slot(settings, slug)
         await _restore_slot_state(settings, slot, app_state=app_state)
         _active_client_sentinel(settings).parent.mkdir(parents=True, exist_ok=True)
-        _active_client_sentinel(settings).write_text(slug)
+        _active_client_sentinel(settings).write_text(slug, encoding="utf-8")
         _set_honcho_client_workspace(slug)
 
 

--- a/packages/core/openexecutive/clients/slots.py
+++ b/packages/core/openexecutive/clients/slots.py
@@ -159,7 +159,7 @@ def get_active_client(settings: Any) -> str | None:
     if not sentinel.exists():
         return None
     try:
-        content = sentinel.read_text().strip()
+        content = sentinel.read_text(encoding="utf-8").strip()
     except Exception:
         return None
     # Same defence-in-depth as the fixture sentinel: garbage never reaches the UI.
@@ -213,7 +213,7 @@ def _read_meta(slot: Path) -> dict[str, Any]:
     if not meta_path.exists():
         return {}
     try:
-        data = json.loads(meta_path.read_text())
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
         return data if isinstance(data, dict) else {}
     except Exception:
         return {}
@@ -222,7 +222,7 @@ def _read_meta(slot: Path) -> dict[str, Any]:
 def _write_meta(slot: Path, **updates: Any) -> None:
     meta = _read_meta(slot)
     meta.update(updates)
-    (slot / "meta.json").write_text(json.dumps(meta, indent=2, default=str))
+    (slot / "meta.json").write_text(json.dumps(meta, indent=2, default=str), encoding="utf-8")
 
 
 async def update_client_meta(
@@ -639,9 +639,20 @@ async def _rebuild_vector_state(settings: Any, app_state: Any | None) -> int:
     company_docs_dir: Path = settings.company_profile_path.parent / "docs"
     docs_indexed = 0
     for doc in sorted(company_docs_dir.glob("*.md")):
-        docs_indexed += await ingest_file(
-            path=doc, store=store, collection=ChromaDBStore.COMPANY_COLLECTION
-        )
+        # Never let one unreadable doc abort the restore. This runs AFTER the DB
+        # and company dir have been swapped but BEFORE the active-client
+        # sentinel is written, so raising here strands live state belonging to
+        # the incoming client while get_active_client() still reports None —
+        # which makes park_active_client a no-op and lets a later
+        # create(source="current") capture that client's data as the operator's
+        # own. A doc that fails to index is a degraded search index; losing the
+        # sentinel is data attribution loss. Mirrors the skills loop below.
+        try:
+            docs_indexed += await ingest_file(
+                path=doc, store=store, collection=ChromaDBStore.COMPANY_COLLECTION
+            )
+        except Exception:
+            logger.exception("client-slots: reindex company doc failed: %s", doc.name)
 
     # Company-authored skills: drop the old client's rows, index the restored set.
     store.delete_documents(collection=SKILLS_COLLECTION, where={"source": "company"})
@@ -831,7 +842,7 @@ async def create_client_slot(
                         "client-slots: pre-create user snapshot failed"
                     )
             saved = _save_slot_state(settings, slot)
-            _active_client_sentinel(settings).write_text(slug)
+            _active_client_sentinel(settings).write_text(slug, encoding="utf-8")
             _set_honcho_client_workspace(slug)
             return {"slug": slug, "display_name": display_name, "active": True, **saved}
 
@@ -923,7 +934,7 @@ async def activate_client_slot(
 
         summary = await _restore_slot_state(settings, slot, app_state=app_state)
         _active_client_sentinel(settings).parent.mkdir(parents=True, exist_ok=True)
-        _active_client_sentinel(settings).write_text(slug)
+        _active_client_sentinel(settings).write_text(slug, encoding="utf-8")
         workspace = _set_honcho_client_workspace(slug)
         if workspace:
             summary["honcho_workspace"] = workspace

--- a/packages/core/openexecutive/evals/scenarios.py
+++ b/packages/core/openexecutive/evals/scenarios.py
@@ -42,7 +42,7 @@ def _load_builtin_scenarios() -> list[dict[str, Any]]:
         return []
     out = []
     for yaml_file in sorted(scenarios_dir.glob("*.yaml")):
-        with open(yaml_file) as f:
+        with open(yaml_file, encoding="utf-8") as f:
             s = yaml.safe_load(f)
         s["_kind"] = scenario_kind(s)
         s["_is_builtin"] = True

--- a/packages/core/openexecutive/fixtures/generator.py
+++ b/packages/core/openexecutive/fixtures/generator.py
@@ -597,10 +597,18 @@ def materialize_to_dir(record: dict[str, Any], target_dir: Path) -> None:
     ``cli.fixture_loader._apply_state_from_source`` consumes.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
-    (target_dir / "profile.yaml").write_text(record.get("profile_yaml") or "")
-    (target_dir / "people.yaml").write_text(record.get("people_yaml") or "")
-    (target_dir / "departments.yaml").write_text(record.get("departments_yaml") or "")
-    (target_dir / "memory.json").write_text(record.get("memory_json") or "{}")
+    (target_dir / "profile.yaml").write_text(
+        record.get("profile_yaml") or "", encoding="utf-8"
+    )
+    (target_dir / "people.yaml").write_text(
+        record.get("people_yaml") or "", encoding="utf-8"
+    )
+    (target_dir / "departments.yaml").write_text(
+        record.get("departments_yaml") or "", encoding="utf-8"
+    )
+    (target_dir / "memory.json").write_text(
+        record.get("memory_json") or "{}", encoding="utf-8"
+    )
 
     docs = json.loads(record.get("docs_json") or "{}")
     if docs:
@@ -612,7 +620,7 @@ def materialize_to_dir(record: dict[str, Any], target_dir: Path) -> None:
             while safe in seen:
                 safe = f"_{safe}"
             seen.add(safe)
-            (docs_dir / safe).write_text(content or "")
+            (docs_dir / safe).write_text(content or "", encoding="utf-8")
 
 
 def _extract_tool_input(response: Any) -> dict[str, Any]:

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -65,7 +65,11 @@ class CompanyProfile(BaseModel):
         path = Path(path)
         if not path.exists():
             return cls()
-        with open(path) as f:
+        # Explicit UTF-8: profile.yaml is routinely hand-edited, so it can hold
+        # real non-ASCII text. Without this, the platform default (cp1252 on
+        # Windows) silently mojibakes it into the cached company-profile prompt
+        # block rather than raising.
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         company_data = data.get("company", data)
         return cls.model_validate(company_data)
@@ -74,7 +78,7 @@ class CompanyProfile(BaseModel):
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {"company": self.model_dump()}
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=True)
 
     def to_prompt_block(self) -> str:

--- a/packages/core/openexecutive/memory/honcho_client.py
+++ b/packages/core/openexecutive/memory/honcho_client.py
@@ -224,7 +224,7 @@ def get_active_workspace_id() -> str:
         if not path.exists():
             return settings.honcho_workspace_id
         import json
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         wid = data.get("workspace_id")
         if isinstance(wid, str) and wid:
             return wid
@@ -250,7 +250,7 @@ def set_active_workspace_id(workspace_id: str, *, fixture_name: str | None = Non
         "fixture_name": fixture_name,
         "set_at": datetime.now(UTC).isoformat(),
     }
-    path.write_text(json.dumps(payload, indent=2))
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
     _drop_cached_clients()
 
 

--- a/packages/core/tests/unit/test_client_slots.py
+++ b/packages/core/tests/unit/test_client_slots.py
@@ -393,6 +393,67 @@ async def test_generated_seed_slot_create_does_not_touch_live(env: SimpleNamespa
     assert listed[0]["origin"] == "generated"
 
 
+# "≈", "→" and "✅" sit outside cp1252, so an unencoded write_text() raises
+# UnicodeEncodeError on a default Windows install. Accented Latin-1 characters
+# alone would NOT reproduce it — they encode fine in cp1252.
+_NON_ASCII_DOC = "Orçamento ≈ R$ 300 → prioridade: presença digital ✅"
+
+
+async def test_generated_slot_pins_encoding_on_every_text_write(
+    env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Slot creation must never write or read text at the platform default.
+
+    ``Path.write_text()`` with no ``encoding`` uses the C-level locale
+    (cp1252 on a default Windows install), which raised mid-write and
+    surfaced as ``ClientSlotError: Failed to write client slot: 'charmap'
+    codec can't encode ...`` for any client whose docs were not
+    cp1252-representable. Doc bodies are the only artifact written verbatim —
+    profile/people/departments YAML and memory.json go through
+    ``yaml.safe_dump`` / ``json.dumps``, which escape non-ASCII and are pure
+    ASCII on disk — but every site in this path is pinned so the next verbatim
+    write is safe by default.
+
+    This asserts the *contract* (each call passes an explicit encoding) rather
+    than simulating a locale, because the locale cannot be faked from Python:
+    patching ``locale.getencoding`` does not affect ``Path.write_text``, which
+    reads the C-level locale. A symptom-based test would therefore be inert on
+    the UTF-8 platform CI runs on, and would police nothing.
+    """
+    real_write, real_read = Path.write_text, Path.read_text
+    offenders: list[str] = []
+
+    def guarded_write(self, data, encoding=None, errors=None, newline=None):  # type: ignore[no-untyped-def]
+        if encoding is None:
+            offenders.append(f"write_text: {self.name}")
+        return real_write(self, data, encoding=encoding or "utf-8", errors=errors, newline=newline)
+
+    def guarded_read(self, encoding=None, errors=None, newline=None):  # type: ignore[no-untyped-def]
+        if encoding is None:
+            offenders.append(f"read_text: {self.name}")
+        return real_read(self, encoding=encoding or "utf-8", errors=errors, newline=newline)
+
+    monkeypatch.setattr(Path, "write_text", guarded_write)
+    monkeypatch.setattr(Path, "read_text", guarded_read)
+
+    bundle = _intake_bundle()
+    bundle["docs"] = [{"filename": "plano.md", "content": _NON_ASCII_DOC}]
+    await create_client_slot(
+        env.settings,
+        display_name="Consultório Ação — Psicologia",
+        slug="consultorio_acao",
+        source="generated",
+        bundle=bundle,
+    )
+    monkeypatch.undo()
+
+    assert offenders == []
+
+    # And the bytes that landed really are UTF-8, losslessly.
+    slot = env.company / "_client_slots" / "consultorio_acao"
+    assert (slot / "docs" / "plano.md").read_bytes().decode("utf-8") == _NON_ASCII_DOC
+
+
 async def test_generated_seed_slot_activation_seeds_org_and_memory(
     env: SimpleNamespace,
 ) -> None:

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -1,4 +1,5 @@
 """Unit tests for CompanyProfile."""
+import builtins
 import tempfile
 from pathlib import Path
 
@@ -42,6 +43,56 @@ def test_profile_yaml_roundtrip():
         assert loaded.annual_revenue_arr == 500000.0
     finally:
         path.unlink(missing_ok=True)
+
+
+def test_profile_yaml_io_pins_utf8(tmp_path: Path, monkeypatch):
+    """profile.yaml must be read and written as UTF-8, not the platform default.
+
+    save_to_yaml goes through yaml.dump with allow_unicode=False, so anything it
+    writes is pure ASCII. But profile.yaml is routinely hand-edited, and such a
+    file is UTF-8 — read at the platform default (cp1252 on Windows) a single
+    em dash came back as three characters, silently corrupting the cached
+    company-profile prompt block instead of raising. Worse,
+    _restore_slot_state re-saved the mojibake, persisting it to the live file.
+
+    Asserts the contract (both sites pass an explicit encoding) rather than the
+    symptom: the locale cannot be faked from Python, so a symptom test would be
+    inert on the UTF-8 platform CI runs on. The value assertions below then
+    confirm the content actually round-trips.
+    """
+    opened: list[str | None] = []
+    real_open = builtins.open
+
+    def guarded_open(file, mode="r", *args, **kwargs):
+        if "b" not in mode and str(file).endswith("profile.yaml"):
+            opened.append(kwargs.get("encoding"))
+            kwargs.setdefault("encoding", "utf-8")
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+
+    path = tmp_path / "profile.yaml"
+    path.write_text(
+        "company:\n"
+        "  name: Consultório Ação\n"
+        "  stage: Pré-operacional — em fase de abertura\n"
+        "  mission: Orçamento ≈ R$ 300 → presença digital\n",
+        encoding="utf-8",
+    )
+
+    loaded = CompanyProfile.load_from_yaml(path)
+    loaded.save_to_yaml(tmp_path / "out" / "profile.yaml")
+    monkeypatch.undo()
+
+    # Both the read and the write passed an explicit encoding.
+    assert opened == ["utf-8", "utf-8"]
+
+    assert loaded.name == "Consultório Ação"
+    assert loaded.stage == "Pré-operacional — em fase de abertura"
+    assert loaded.mission == "Orçamento ≈ R$ 300 → presença digital"
+    # The em dash must survive as one character, not three mojibake bytes.
+    assert loaded.stage.count("—") == 1
+    assert "â" not in loaded.stage
 
 
 def test_prompt_block_includes_financials():


### PR DESCRIPTION
## What

`Path.write_text()` / `read_text()` / `open()` without `encoding` use the **C-level locale** — cp1252 on a default Windows install. Two live bugs came out of that; both are Windows-only, which is why CI never caught them.

### 1. Creating a client slot aborted outright

`POST /clients` with `source="generated"` failed whenever a document body held a character outside cp1252:

```
ClientSlotError: Failed to write client slot: 'charmap' codec can't encode character '≈'
```

Doc bodies are the **only** slot artifact written verbatim. `profile.yaml`, `people.yaml`, `departments.yaml` and `memory.json` go through `yaml.safe_dump` (`allow_unicode=False`) and `json.dumps` (`ensure_ascii=True`), so those are pure ASCII on disk and were never at risk. Exactly one of the pinned sites was load-bearing; the rest are defensive, so the next verbatim write is safe by default.

### 2. `profile.yaml` was silently mojibaked — and the corruption was persisted

`CompanyProfile.load_from_yaml` read the file at the platform default. A single em dash came back as **three** characters, flowed into the cached company-profile prompt block, and then `_restore_slot_state` re-saved it — writing the corruption back to the live `company/profile.yaml`.

Reproduced on a real profile, and it was visible in the API response before the fix:

```
"stage": "Pre-revenue / pre-launch â€” converting first pilot clinic"   # before
"stage": "Pre-revenue / pre-launch — converting first pilot clinic"     # after
```

Silent, not an exception — so nothing surfaced it.

## Also in here

**Three readers of hand-authored UTF-8 files**, found while tracing every reader/writer pair:
- `architecture/facts.py` — `architecture-facts.yaml` holds 708 non-ASCII characters and was being mojibaked
- `evals/scenarios.py`
- `memory/honcho_client.py` — the workspace map, inside the slot-activation path

**A `try/except` on the company-doc reindex loop** in `_rebuild_vector_state`, matching the one its sibling skills loop already had. That loop runs *after* the DB and company dir are swapped but *before* the active-client sentinel is written. Raising there left live state belonging to the incoming client while `get_active_client()` still reported `None` — which makes `park_active_client` a no-op and lets a later `create(source="current")` capture that client's data as the operator's own. A doc that fails to index is a degraded search index; losing the sentinel is data-attribution loss.

## Tests

Two regression tests that assert the **contract** — each call site passes an explicit encoding — rather than the symptom.

This is deliberate. The locale cannot be faked from Python: patching `locale.getencoding` does **not** affect `Path.write_text`, which reads the C-level locale. A symptom-based test therefore passes with or without the fix on a UTF-8 platform and would police nothing in CI. Verified by reverting both fixes under `PYTHONUTF8=1` — both tests fail; restored, both pass.

## Verification

- `ruff check openexecutive/` — clean
- `mypy openexecutive/` — 280 files, no issues
- Full unit suite — 2837 passed; the 11 failures are the pre-existing local-only set documented in `CLAUDE.md` (Windows path separators, Bedrock web-search toggle, provider registry), with a failure list byte-identical to the baseline taken before these changes
- End-to-end on a live server: slot creation succeeds and `GET /clients` returns correct UTF-8

## Not addressed

Slots written by the old code on Windows may hold cp1252 `docs/*.md`. `knowledge/loader.py` reads those as UTF-8 with no `errors=`, so activating such a legacy slot can still fail to index those files — now logged rather than fatal, thanks to the `try/except` above. No such file exists on the install this was found on (37 non-ASCII files scanned, all UTF-8), and this change prevents new ones. A one-time re-encode pass would be a separate PR.