### PR TITLE
feat(ui): AUTH_DEV_BYPASS local sign-in without Google; enforce allowlist revocation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ AUTH_GOOGLE_SECRET=
 ALLOWED_EMAILS=alice@example.com,bob@example.com
 AUTH_TRUST_HOST=true
 AUTH_URL=
+# AUTH_DEV_BYPASS=true skips Google sign-in under `make dev`: /signin auto-signs
+#   you in as the first ALLOWED_EMAILS entry. Honoured only when NODE_ENV is
+#   not "production" (`next build` sets it), so it is inert on deployed builds.
+#   With the flag on, `make dev` binds the UI to 127.0.0.1 instead of 0.0.0.0
+#   so nothing on your LAN can use the bypass.
+AUTH_DEV_BYPASS=false
 
 # Shared secret between the Next.js proxy and the FastAPI backend. The UI
 # attaches this as `x-api-key`; the API requires it on every non-exempt

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 dev:
 	@echo "Starting Open Executive..."
 	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; cd packages/core && uv run uvicorn openexecutive.api.main:app --reload --port 8000 &
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; cd packages/ui && npm run dev
+	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; cd packages/ui && if [ "$$AUTH_DEV_BYPASS" = "true" ]; then npm run dev -- -H 127.0.0.1; else npm run dev; fi
 
 stop:
 	@lsof -ti :8000 -ti :3000 2>/dev/null | xargs kill -9 2>/dev/null || true

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -82,6 +82,23 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 Then `make dev` and visit http://localhost:3000.
 
+#### Skipping Google locally
+
+No OAuth client yet? Set `AUTH_DEV_BYPASS=true` in the root `.env` and run
+`make dev` (the `make docker` UI service does not forward the flag). `/signin`
+then signs you in automatically as the first `ALLOWED_EMAILS` entry (via an
+Auth.js Credentials provider registered only when the flag is on), and every
+downstream check — middleware, backend proxy, `x-caller-email`, the allow-list
+callbacks — runs unchanged. Two guards keep it local: the provider is
+registered only when `NODE_ENV` is not `production` (`next build` hard-sets
+`production`, so the flag is inert on Fly or any other built deployment), and
+`make dev` binds the UI to `127.0.0.1` instead of the usual `0.0.0.0` while the
+flag is on, so nothing else on your network can reach the dev server. (The
+provider also rejects non-loopback `Host` headers, but that is a tripwire, not
+a boundary — `Host` is client-supplied.) If you start `next dev` by hand with
+the flag on, pass `-H 127.0.0.1` yourself. "Sign out" in the UI lands on
+`/signin`, which signs you straight back in while the flag is on.
+
 For Docker, use `make docker` (not a bare `docker compose -f
 docker/docker-compose.yml up`): the Makefile passes `--env-file .env`, which
 is what feeds the UI container's `AUTH_*` / `BACKEND_SHARED_SECRET` values.

--- a/packages/core/openexecutive/architecture/architecture-facts.yaml
+++ b/packages/core/openexecutive/architecture/architecture-facts.yaml
@@ -2132,6 +2132,20 @@ auth:
          only when the roster is empty (fresh-install bootstrap).
          Once any Person has an email, the env var is ignored.
     Roster fetch is cached for 5 minutes per Next.js server instance.
+    The `authorized` callback must return a Response to deny: because
+    middleware.ts passes its own handler to `auth()`, next-auth discards a
+    boolean false there and runs the handler anyway. Both deny paths share
+    `denyResponse()` in auth.ts (JSON 401 for /api/*, /signin redirect
+    otherwise); /signin itself re-checks the allowlist so a revoked session
+    sees an AccessDenied message instead of a redirect loop.
+    Local-dev bypass: AUTH_DEV_BYPASS=true registers a Credentials
+    provider (`dev-bypass`) that /signin auto-submits, signing in as the
+    first ALLOWED_EMAILS entry. Same signIn/authorized allowlist gate
+    applies. Registered only when NODE_ENV != production (so `next build`
+    output on Fly never honours the flag); `make dev` binds next to
+    127.0.0.1 while the flag is on, which is the actual network boundary
+    (the provider's loopback-Host check is only a tripwire — Host is
+    client-supplied).
   backend_gate: |
     BACKEND_SHARED_SECRET via x-api-key header gates every API route
     (see api.main._shared_secret_gate). The Next.js proxy at

--- a/packages/ui/src/app/signin/page.tsx
+++ b/packages/ui/src/app/signin/page.tsx
@@ -1,5 +1,6 @@
-import { signIn, auth } from "@/auth";
+import { signIn, auth, checkEmailAllowed, DEV_BYPASS_EMAIL } from "@/auth";
 import { redirect } from "next/navigation";
+import DevAutoSignIn from "@/components/DevAutoSignIn";
 
 type SearchParams = Promise<{ callbackUrl?: string; error?: string }>;
 
@@ -15,13 +16,18 @@ export default async function SignInPage({ searchParams }: { searchParams: Searc
   const { callbackUrl, error } = await searchParams;
   const safeDest = safeCallbackUrl(callbackUrl);
 
-  // If already signed in, bounce straight to the destination.
+  // If already signed in, bounce straight to the destination — unless the
+  // session's email has since left the allowlist, in which case the
+  // middleware would send it straight back here. Show the denial instead.
   const session = await auth();
-  if (session?.user) {
-    redirect(safeDest);
+  let denied = false;
+  if (session?.user?.email) {
+    const { allowed, source } = await checkEmailAllowed(session.user.email.toLowerCase());
+    if (allowed || source === "env_after_fetch_error") redirect(safeDest);
+    denied = true;
   }
 
-  const errorMessage = error ? describeError(error) : null;
+  const errorMessage = error ? describeError(error) : denied ? describeError("AccessDenied") : null;
 
   return (
     <main className="min-h-screen flex items-center justify-center px-6">
@@ -33,6 +39,10 @@ export default async function SignInPage({ searchParams }: { searchParams: Searc
           <p className="mt-4 rounded-md border border-red-900/50 bg-red-950/40 px-3 py-2 text-sm text-red-200">
             {errorMessage}
           </p>
+        )}
+
+        {DEV_BYPASS_EMAIL && !errorMessage && (
+          <DevAutoSignIn email={DEV_BYPASS_EMAIL} redirectTo={safeDest} />
         )}
 
         <form

--- a/packages/ui/src/auth.ts
+++ b/packages/ui/src/auth.ts
@@ -1,5 +1,8 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
+import Credentials from "next-auth/providers/credentials";
+import type { Provider } from "next-auth/providers";
+import type { NextRequest } from "next/server";
 
 // Env-var fallback for the bootstrap case (fresh install, roster still
 // empty). Once any Person row exists with an email, the backend's
@@ -11,6 +14,43 @@ const ALLOWED_EMAILS_FALLBACK: ReadonlySet<string> = new Set(
     .map((e) => e.trim().toLowerCase())
     .filter((e) => e.length > 0),
 );
+
+// Local-dev bypass: when AUTH_DEV_BYPASS=true, /signin auto-signs in as the
+// first ALLOWED_EMAILS entry without touching Google. `next build` hard-sets
+// NODE_ENV=production, so this is inert on every deployed build even if the
+// env var leaks there. The email still goes through the same allowlist gate
+// as a Google login (signIn + authorized callbacks below).
+export const DEV_BYPASS_EMAIL: string | null =
+  process.env.AUTH_DEV_BYPASS === "true" && process.env.NODE_ENV !== "production"
+    ? ([...ALLOWED_EMAILS_FALLBACK][0] ?? null)
+    : null;
+
+if (process.env.AUTH_DEV_BYPASS === "true" && !DEV_BYPASS_EMAIL) {
+  console.warn(
+    "[auth] AUTH_DEV_BYPASS=true ignored: " +
+      (process.env.NODE_ENV === "production" ? "NODE_ENV is production" : "ALLOWED_EMAILS is empty"),
+  );
+}
+
+const providers: Provider[] = [Google];
+if (DEV_BYPASS_EMAIL) {
+  providers.push(
+    Credentials({
+      id: "dev-bypass",
+      name: "Dev bypass",
+      credentials: {},
+      // Tripwire, not a boundary: Host is client-supplied, so a LAN peer
+      // can send `Host: localhost`. The boundary is the bind address —
+      // `make dev` passes `-H 127.0.0.1` to next when the flag is on. This
+      // check only rejects accidental use via a LAN IP or hostname.
+      authorize: async (_credentials, request) => {
+        const host = request.headers.get("host") ?? "";
+        if (!/^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(host)) return null;
+        return { email: DEV_BYPASS_EMAIL, name: "Dev User" };
+      },
+    }),
+  );
+}
 
 const BACKEND_BASE = process.env.BACKEND_BASE_URL ?? "http://localhost:8000";
 const BACKEND_SHARED_SECRET = process.env.BACKEND_SHARED_SECRET ?? "";
@@ -61,7 +101,7 @@ async function fetchRosterEmails(): Promise<Set<string> | null> {
  * the `authorized` callback (re-runs on every gated request so a user
  * removed from the roster mid-session is bounced on next request).
  */
-async function checkEmailAllowed(
+export async function checkEmailAllowed(
   email: string,
 ): Promise<{ allowed: boolean; source: string }> {
   const roster = await fetchRosterEmails();
@@ -93,8 +133,19 @@ function auditAuth(
   });
 }
 
+// Deny response for a middleware-gated request. API routes get JSON 401 so
+// fetch() callers don't follow an HTML redirect; pages go to /signin.
+export function denyResponse(req: NextRequest): Response {
+  if (req.nextUrl.pathname.startsWith("/api/")) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const signInUrl = new URL("/signin", req.nextUrl.origin);
+  signInUrl.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
+  return Response.redirect(signInUrl);
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [Google],
+  providers,
   // 24h JWT TTL. Defence in depth alongside the `authorized` re-check
   // below — a session that somehow drifts out of sync with the roster
   // is corrected on next access, but also naturally expires within a
@@ -108,13 +159,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // Strict initial gate. Requires `email_verified === true` explicitly: a
     // missing / non-boolean value fails closed. Google always returns true
     // for real accounts.
-    signIn: async ({ profile }) => {
-      const email = profile?.email?.toLowerCase();
+    signIn: async ({ user, account, profile }) => {
+      // Credentials sign-ins carry no OAuth profile; the dev bypass provider
+      // only exists when DEV_BYPASS_EMAIL is set (see above).
+      const isDevBypass = account?.provider === "dev-bypass";
+      const email = (isDevBypass ? user.email : profile?.email)?.toLowerCase();
       if (!email) {
         auditAuth("auth_login", "Login denied: no email", null, { denied: true, reason: "no_email" });
         return false;
       }
-      if (profile?.email_verified !== true) {
+      if (!isDevBypass && profile?.email_verified !== true) {
         auditAuth("auth_login", `Login denied: ${email} (email not verified)`, email, { denied: true, reason: "email_not_verified" });
         return false;
       }
@@ -137,7 +191,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // source === "env_after_fetch_error") so a brief backend hiccup
     // doesn't lock out everyone with a valid session — the strict
     // `signIn` gate already vetted them once.
-    authorized: async ({ auth }) => {
+    //
+    // Must return a Response to deny: because middleware.ts passes its own
+    // handler to `auth()`, next-auth ignores a boolean `false` here and
+    // runs the handler anyway (lib/index.js handleAuth). The no-session
+    // case is left to the handler.
+    authorized: async ({ auth, request }) => {
       if (!auth?.user?.email) return false;
       const email = auth.user.email.toLowerCase();
       const { allowed, source } = await checkEmailAllowed(email);
@@ -151,14 +210,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           email,
           { revoked: true, reason: "not_in_allowlist", source },
         );
+        return denyResponse(request);
       }
-      return allowed;
+      return true;
     },
   },
   events: {
-    signIn: ({ user }) => {
+    signIn: ({ user, account }) => {
       const email = user.email?.toLowerCase() ?? null;
-      auditAuth("auth_login", `Login: ${email ?? "unknown"}`, email, { provider: "google" });
+      auditAuth("auth_login", `Login: ${email ?? "unknown"}`, email, { provider: account?.provider ?? "unknown" });
     },
     signOut: (message) => {
       // JWT strategy sends { token }, session strategy sends { session }.

--- a/packages/ui/src/components/DevAutoSignIn.tsx
+++ b/packages/ui/src/components/DevAutoSignIn.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useEffect } from "react";
+
+// Rendered by /signin only when the AUTH_DEV_BYPASS provider is active (see
+// DEV_BYPASS_EMAIL in auth.ts). Kicks off the credentials flow on mount so
+// the sign-in page is never seen during local dev. The page skips this
+// component when `?error=` is present, so a denied dev email shows the
+// error instead of looping.
+export default function DevAutoSignIn({ email, redirectTo }: { email: string; redirectTo: string }) {
+  useEffect(() => {
+    void signIn("dev-bypass", { redirectTo });
+  }, [redirectTo]);
+
+  return (
+    <p className="mt-4 text-sm text-fg-muted">
+      Signing in as {email} (AUTH_DEV_BYPASS)…
+    </p>
+  );
+}

--- a/packages/ui/src/middleware.ts
+++ b/packages/ui/src/middleware.ts
@@ -1,20 +1,12 @@
-import { auth } from "@/auth";
+import { auth, denyResponse } from "@/auth";
 
 // Gate every page + non-auth API route. `auth` from NextAuth v5 wraps a
-// handler that injects req.auth; here we use it directly as middleware, which
-// makes unauthenticated requests redirect to the configured sign-in page.
+// handler that injects req.auth. Sessions whose email has since left the
+// allowlist never reach this handler — the `authorized` callback in auth.ts
+// returns the deny Response itself. This handler covers no-session only.
 export default auth((req) => {
   if (req.auth) return;
-
-  // For API routes, return JSON 401 instead of an HTML redirect so the
-  // browser doesn't follow it and break fetch() callers.
-  if (req.nextUrl.pathname.startsWith("/api/")) {
-    return Response.json({ error: "unauthorized" }, { status: 401 });
-  }
-
-  const signInUrl = new URL("/signin", req.nextUrl.origin);
-  signInUrl.searchParams.set("callbackUrl", req.nextUrl.pathname + req.nextUrl.search);
-  return Response.redirect(signInUrl);
+  return denyResponse(req);
 });
 
 // Exclude Auth.js's own routes, Next internals, static assets, and exactly


### PR DESCRIPTION
## Summary

Local development without a Google OAuth client, plus a fix for a pre-existing allowlist-revocation hole that review surfaced.

**Dev bypass (`AUTH_DEV_BYPASS=true`)**
- Registers an Auth.js Credentials provider `dev-bypass` that signs in as the first `ALLOWED_EMAILS` entry. `/signin` auto-submits it on mount, so the page is never seen locally.
- Everything downstream runs unchanged: middleware, backend proxy, `x-caller-email`, and the `signIn` / `authorized` allowlist callbacks (a dev email absent from a populated roster is still denied).
- Boundaries: the provider is registered only when `NODE_ENV != production` (`next build` output on Fly never honours the flag), and `make dev` binds Next to `127.0.0.1` while the flag is on so nothing on the LAN can reach the dev server. The provider's loopback-`Host` check is a tripwire only, since `Host` is client-supplied. A `console.warn` explains when the flag is ignored.

**Pre-existing hole fixed: `authorized` result was discarded**
Because `middleware.ts` passes its own handler to `auth()`, next-auth (`lib/index.js` `handleAuth`) computes the `authorized` callback's boolean and then runs the handler regardless. A user removed from the roster kept full access, including proxied backend calls stamped with their email, for the whole 24h JWT, while the audit log claimed the session was revoked. `authorized` now returns a deny `Response` via a shared `denyResponse()` (JSON 401 for `/api/*`, `/signin` redirect otherwise), the middleware handler covers only the no-session case, and `/signin` re-checks the allowlist so a revoked session sees AccessDenied instead of a redirect loop.

Docs updated: `.env.example`, `docs/auth.md`, `architecture-facts.yaml` (`auth.ui_provider`).

## Verification

Runtime, against `next dev` and a `next start` production build (roster stubbed where noted):

| Case | Result |
|---|---|
| flag on, dev, loopback | session minted; `/` 200 with cookie, 302 without; proxy 200 / 401 |
| flag on, dev, revoked email (roster stub) | `/` 302 to `/signin`; proxy 401; `/signin` shows AccessDenied, no loop |
| flag on, dev, `Host: 192.168.1.5` / `evil.example` | CredentialsSignin, no session |
| flag off, dev, forged callback | provider not found, no session |
| flag on, production build, forged callback | provider not found, no session; warn logged |
| `make dev` bind with flag on | listener on 127.0.0.1 only; LAN IP refused |

`npm run build` passes. Three adversarial review rounds (security / logic / quality) drove the revocation fix, the loopback bind, the Docker-path doc correction, and the ignore warning.

## Known limits

- Bare `npm run dev` with the flag on still binds `0.0.0.0`; docs say to pass `-H 127.0.0.1`. The Makefile path is covered.
- `make docker` does not forward `AUTH_DEV_BYPASS` (documented; intentional).
- Separate issue, not in this PR: `.env.example` ships a blank `AUTH_URL=` which makes `make dev` fail with `UntrustedHost` (empty string is not nullish in Auth.js's `AUTH_URL ?? AUTH_TRUST_HOST` chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u8cAn5hK6q7VAti5jAShq
