### PR TITLE
fix(clients): stop derived caches leaking across companies

### DIFF
--- a/packages/core/openexecutive/architecture/architecture-facts.yaml
+++ b/packages/core/openexecutive/architecture/architecture-facts.yaml
@@ -2715,6 +2715,37 @@ clients:
     blank slot (no state.db yet) factory-wipes the per-client tables and
     re-seeds defaults (departments, onboarding templates, principal briefs,
     cadences) so the new client's Today works without a process restart.
+    Wipe lists must cover the DERIVED CACHES, not just authored state.
+    briefing_narrative and person_insights were wiped by NO path, and because
+    /today serves the cached narrative unconditionally (regenerating only in a
+    BackgroundTask), whichever path swapped the company rendered the OUTGOING
+    one's narrative under the incoming one. Do not assume person_insights'
+    input_hash self-guards: that hash covers role/status/counters/UTC-day but
+    NOT person or company identity, and the key is a reused autoincrement
+    person_id — so an outgoing principal and a freshly seeded incoming
+    principal hash identically. Ordinary steady state, not a collision.
+    THREE paths swap live company state and each kept its own hand-written
+    table list, which is why fixing one left the leak live in the other two.
+    They now all consume `cli.fixture_loader.PER_CLIENT_CACHE_TABLES`:
+    `clients.slots._BLANK_WIPE_TABLES` (switch into a blank/seed slot),
+    `reset_all_state` (factory reset), and `_seed_episodic_memory` (fixture
+    load — the worst surface, since a demo is what gets screen-shared).
+    Client→client switching into a slot that HAS state.db was already safe:
+    the sqlite backup API truncates the destination to an exact copy.
+    Add any new per-company cache table to that constant, once.
+    Graded as NOT wiped: generated_fixtures (operator-level, see
+    _GLOBAL_TABLES) and architecture_sections (repo-derived, keyed by a hash of
+    the facts file). Still UNGRADED, deliberately deferred: dynamic_workflows
+    and eval_scenarios. These ARE client-scoped — the non-blank path already
+    swaps them with the whole DB — and on the blank path the outgoing client's
+    workflow definitions stay registered AND active (`list_definitions(
+    active_only=True)`), runnable against the incoming client's data, with full
+    bodies exposed via /workflows. They are not in the wipe list because they
+    are authored, not derived, and `snapshot_user_state` (the first-activation
+    branch, when no client is active) captures only profile/docs/memory.json/
+    people/departments — so wiping them there would irrecoverably delete the
+    operator's own work. The fix is to capture them in that snapshot FIRST,
+    then wipe. Both tables are empty on current installs.
   invariants:
     - At most one slot is active; the .active_client sentinel records it
       (allowlist-validated on read, same defence as the fixture sentinel).

--- a/packages/core/openexecutive/cli/fixture_loader.py
+++ b/packages/core/openexecutive/cli/fixture_loader.py
@@ -65,6 +65,28 @@ _FIXTURE_OP_LOCK = asyncio.Lock()
 # sentinel file so a tampered/garbage value cannot reach the UI.
 _SAFE_NAME_RE = re.compile(r"^[a-z0-9_-]+$")
 
+# Per-company DERIVED caches in the episodic DB. Regenerable, so always safe to
+# drop — and they MUST be dropped by every path that swaps the live company,
+# because /today serves them from cache and only regenerates in a
+# BackgroundTask. Leave a row behind and the next request renders the OUTGOING
+# company's text under the incoming one: observed live, one client's briefing
+# narrative appearing verbatim under another.
+#
+# Three separate paths swap live company state, and each maintained its own
+# hand-written table list — so this was fixed in one and still live in the other
+# two. They now all consume this constant: `clients.slots._BLANK_WIPE_TABLES`
+# (client switch into a blank/seed slot), `reset_all_state` (factory reset), and
+# `_seed_episodic_memory` (fixture load). Any new per-company cache table goes
+# here, once.
+#
+# Not included, deliberately: `generated_fixtures` (operator-level, see
+# `slots._GLOBAL_TABLES`) and `architecture_sections` (repo-derived, keyed by a
+# hash of the facts file — not company data).
+PER_CLIENT_CACHE_TABLES: tuple[str, ...] = (
+    "briefing_narrative",
+    "person_insights",
+)
+
 # Walk up from this file to find the repo root (contains evals/, fixtures/, etc.)
 # Match on ``fixtures/companies`` specifically — NOT a bare ``fixtures`` dir —
 # so the in-package ``openexecutive/fixtures/`` module (generated-fixture store
@@ -671,6 +693,14 @@ async def reset_all_state(
         # circuit (and there's nothing to wipe in a DB that isn't there).
         if EPISODIC_DB_PATH.exists():
             monitoring_store.initialize_db(EPISODIC_DB_PATH)
+            # Same reasoning for the derived caches in PER_CLIENT_CACHE_TABLES:
+            # both create their table lazily on first put/get, so a DB that has
+            # never served a briefing lacks them and the DELETE pass would raise.
+            from openexecutive.briefing import narrative_cache
+            from openexecutive.people import insights_cache
+
+            narrative_cache.initialize_db(EPISODIC_DB_PATH)
+            insights_cache.initialize_db(EPISODIC_DB_PATH)
         episodic_cleared = _delete_all_rows(
             EPISODIC_DB_PATH,
             (
@@ -689,6 +719,7 @@ async def reset_all_state(
                 "eval_runs",
                 "external_signals",
                 "watchlist",
+                *PER_CLIENT_CACHE_TABLES,
             ),
         )
 
@@ -1135,6 +1166,18 @@ def _seed_episodic_memory(memory_path: Path, settings: Any) -> dict[str, int]:
         )
         if alerts_table_exists:
             conn.execute("DELETE FROM alerts")
+
+        # Derived per-company caches. Without this, loading a fixture over a
+        # live company leaves that company's cached briefing narrative in
+        # place and the demo's /today renders it verbatim — the surface most
+        # likely to be screen-shared. Same existence guard as alerts above:
+        # a minimal/legacy DB may not have these tables yet.
+        for cache_table in PER_CLIENT_CACHE_TABLES:
+            if conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+                (cache_table,),
+            ).fetchone():
+                conn.execute(f"DELETE FROM {cache_table}")  # noqa: S608 — fixed tuple
 
         decisions = data.get("decisions", [])
         for row in decisions:

--- a/packages/core/openexecutive/clients/slots.py
+++ b/packages/core/openexecutive/clients/slots.py
@@ -45,6 +45,9 @@ from openexecutive.cli.fixture_loader import (
     get_fixture_status,
     snapshot_user_state,
 )
+from openexecutive.cli.fixture_loader import (
+    PER_CLIENT_CACHE_TABLES as _PER_CLIENT_CACHE_TABLES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +85,18 @@ ENGAGEMENT_STATUSES = ("active", "paused", "winding_down", "completed")
 # Ordered children-before-parents for PRAGMA foreign_keys=ON. Existence-guarded
 # at delete time, so stores that haven't initialized on this box are skipped.
 _BLANK_WIPE_TABLES = (
+    # Derived caches first — see PER_CLIENT_CACHE_TABLES for why they must be
+    # wiped by every company-swapping path, not just this one. Neither declares
+    # a foreign key, so head position is free.
+    #
+    # Do not assume person_insights' input_hash makes it self-guarding: the hash
+    # (people.insights.build_insight_input_hash) covers role, is_principal,
+    # status, counters, availability and the UTC day — NOT the person's name or
+    # id. The cache key is person_id, a reused autoincrement PK. So an outgoing
+    # principal and a freshly seeded incoming principal, both with no awaiting
+    # work on the same day, hash identically and the stale note is served. That
+    # is an ordinary steady state for a seeded slot, not a collision.
+    *_PER_CLIENT_CACHE_TABLES,
     "chat_messages",
     "sessions",
     "decisions",

--- a/packages/core/tests/unit/test_client_slots.py
+++ b/packages/core/tests/unit/test_client_slots.py
@@ -393,6 +393,96 @@ async def test_generated_seed_slot_create_does_not_touch_live(env: SimpleNamespa
     assert listed[0]["origin"] == "generated"
 
 
+async def test_seed_slot_activation_clears_derived_caches(env: SimpleNamespace) -> None:
+    """The outgoing client's cached narrative/insights must not survive a switch.
+
+    /today serves the cached briefing narrative unconditionally and only
+    regenerates in a background task (api/routes/today.py::_attach_narrative),
+    so a surviving row renders the PREVIOUS client's narrative under the
+    incoming one — observed live, one client's briefing appearing verbatim
+    under another. Both tables are regenerable caches, so wiping is free.
+    """
+    from openexecutive.briefing import narrative_cache
+    from openexecutive.people import insights_cache
+
+    _seed_live_company(env, "Outgoing Co")
+    narrative_cache.put(
+        narrative_cache.BriefingNarrative(
+            scope="principal",
+            input_hash="stale-hash",
+            narrative_text="**Outgoing Co is straining** — do not show this elsewhere.",
+            generated_at="2026-09-01T00:00:00+00:00",
+        )
+    )
+    insights_cache.put(
+        insights_cache.PersonInsight(
+            person_id=1,
+            input_hash="stale-hash",
+            insight_text="Outgoing Co founder is unreachable.",
+            generated_at="2026-09-01T00:00:00+00:00",
+        )
+    )
+    # Both caches are warm for the outgoing client.
+    assert narrative_cache.get("principal") is not None
+    assert insights_cache.get(1) is not None
+
+    await create_client_slot(
+        env.settings,
+        display_name="Incoming Co",
+        source="generated",
+        bundle=_intake_bundle(),
+    )
+    await activate_client_slot(env.settings, "incoming_co")
+
+    assert narrative_cache.get("principal") is None
+    assert insights_cache.get(1) is None
+
+
+async def test_switch_preserves_outgoing_caches_in_its_slot(env: SimpleNamespace) -> None:
+    """Wiping the caches on switch must not DESTROY them — only unpublish them.
+
+    The wipe has to happen after the outgoing client's VACUUM INTO save-back, so
+    its cached narrative lands in state.db and returns on reactivation. Ordering
+    the wipe before the save-back would lose it permanently, and the sibling
+    test above cannot catch that: there, no client is active, so the save-back
+    branch of activate_client_slot never runs.
+    """
+    from openexecutive.briefing import narrative_cache
+    from openexecutive.people import insights_cache
+
+    _seed_live_company(env, "Client A")
+    await create_client_slot(env.settings, display_name="Client A", source="current")
+    narrative_cache.put(
+        narrative_cache.BriefingNarrative(
+            scope="principal",
+            input_hash="a-hash",
+            narrative_text="**Client A narrative**",
+            generated_at="2026-09-01T00:00:00+00:00",
+        )
+    )
+    insights_cache.put(
+        insights_cache.PersonInsight(
+            person_id=1,
+            input_hash="a-hash",
+            insight_text="Client A insight",
+            generated_at="2026-09-01T00:00:00+00:00",
+        )
+    )
+    await save_active_client(env.settings)
+
+    await create_client_slot(env.settings, display_name="Client B", source="blank")
+    await activate_client_slot(env.settings, "client_b")
+    assert narrative_cache.get("principal") is None
+
+    await activate_client_slot(env.settings, "client_a")
+    restored = narrative_cache.get("principal")
+    assert restored is not None
+    assert restored.narrative_text == "**Client A narrative**"
+    restored_insight = insights_cache.get(1)
+    assert restored_insight is not None
+    assert restored_insight.insight_text == "Client A insight"
+
+
 async def test_generated_seed_slot_activation_seeds_org_and_memory(
     env: SimpleNamespace,
 ) -> None:

--- a/packages/core/tests/unit/test_fixture_loader_clears_watchlist.py
+++ b/packages/core/tests/unit/test_fixture_loader_clears_watchlist.py
@@ -23,6 +23,7 @@ import inspect
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -141,3 +142,92 @@ def test_apply_state_from_source_resets_research_skip_gate() -> None:
         "a fixture reload within 24h will skip its seeded research scan and "
         "surface zero findings."
     )
+
+
+# ── Derived per-company caches (same leak class as the watchlist above) ──────
+#
+# briefing_narrative and person_insights were wiped by NO path. Because /today
+# serves them from cache and only regenerates in a BackgroundTask, loading a
+# demo fixture over a live company rendered that company's real briefing
+# narrative verbatim under the demo — on the surface most likely to be
+# screen-shared. All three swapping paths now consume PER_CLIENT_CACHE_TABLES.
+
+
+def test_seed_episodic_memory_clears_derived_caches(
+    _episodic_db: Path, tmp_path: Path
+) -> None:
+    """The fixture-load seeder must drop the outgoing company's cached text.
+
+    Behavioural, not a source grep: ``_seed_episodic_memory`` is cheap, and it
+    resolves the DB via ``episodic.DB_PATH`` imported at call time, which the
+    ``_episodic_db`` fixture monkeypatches — so the wipe is proven against the
+    live schema rather than asserted from source.
+    """
+    import json
+
+    from openexecutive.briefing import narrative_cache
+    from openexecutive.cli.fixture_loader import _seed_episodic_memory
+    from openexecutive.people import insights_cache
+
+    # First arg is the fixture's memory.json, NOT a db path; an absent or
+    # unparseable file short-circuits before the wipe, so it must be real.
+    memory_path = tmp_path / "memory.json"
+    memory_path.write_text(json.dumps({"decisions": []}), encoding="utf-8")
+
+    narrative_cache.put(
+        narrative_cache.BriefingNarrative(
+            scope="principal",
+            input_hash="outgoing",
+            narrative_text="**Real client narrative** — must not reach a demo.",
+            generated_at=datetime.now(UTC).isoformat(),
+        ),
+        db_path=_episodic_db,
+    )
+    insights_cache.put(
+        insights_cache.PersonInsight(
+            person_id=1,
+            input_hash="outgoing",
+            insight_text="Real client founder note.",
+            generated_at=datetime.now(UTC).isoformat(),
+        ),
+        db_path=_episodic_db,
+    )
+    assert narrative_cache.get("principal", db_path=_episodic_db) is not None
+    assert insights_cache.get(1, db_path=_episodic_db) is not None
+
+    # settings has no episodic_db_path, so the seeder falls back to the
+    # monkeypatched episodic.DB_PATH — i.e. _episodic_db.
+    _seed_episodic_memory(memory_path, SimpleNamespace())
+
+    assert narrative_cache.get("principal", db_path=_episodic_db) is None
+    assert insights_cache.get(1, db_path=_episodic_db) is None
+
+
+def test_wipe_lists_consume_the_shared_cache_constant() -> None:
+    """All three swapping paths must reference the one constant, not copies.
+
+    The original bug was three hand-maintained table lists over one DB: the fix
+    landed in one and the leak stayed live in the other two. Source-grep for the
+    heavy async ``reset_all_state`` (same cheap guard the monitoring tables use)
+    and for the shared constant in the slot wipe list.
+    """
+    from openexecutive.cli.fixture_loader import (
+        PER_CLIENT_CACHE_TABLES,
+        _seed_episodic_memory,
+    )
+    from openexecutive.clients.slots import _BLANK_WIPE_TABLES
+
+    assert PER_CLIENT_CACHE_TABLES == ("briefing_narrative", "person_insights")
+
+    for fn in (reset_all_state, _seed_episodic_memory):
+        assert "PER_CLIENT_CACHE_TABLES" in inspect.getsource(fn), (
+            f"{fn.__name__} no longer consumes PER_CLIENT_CACHE_TABLES — the "
+            "outgoing company's cached briefing narrative will survive and be "
+            "rendered under the incoming one."
+        )
+
+    for table in PER_CLIENT_CACHE_TABLES:
+        assert table in _BLANK_WIPE_TABLES, (
+            f"{table!r} dropped out of the client-slot wipe list — switching "
+            "into a blank/seed slot will leak the previous client's cache."
+        )


### PR DESCRIPTION
## The bug

`briefing_narrative` and `person_insights` were wiped by **no** path that swaps the live company.

`/today` serves both from cache and only regenerates in a `BackgroundTask` (`api/routes/today.py::_attach_narrative` sets `response.narrative` before it checks the hash), so the first request after a swap rendered the **outgoing** company's text under the incoming one. Observed live: one client's briefing narrative appearing verbatim under another.

It isn't UI-only. `PersonBriefItem.insight` comes straight from `insights_cache` and flows outbound through the Discord bot, the MCP server, `morning_brief`, `end_of_day_digest`, and `executive_reflection` — so stale cross-company text could be DM'd.

## Why the fix touches three places

Three paths swap live company state, and each kept its own hand-written table list over the same DB. Fixing one would have left the leak live in the other two — the worst of which is the fixture path, because a demo loaded over a live company rendered that company's real briefing, and a demo is what gets screen-shared.

`PER_CLIENT_CACHE_TABLES` is hoisted into `cli.fixture_loader` and consumed by all three:

| Path | Trigger |
|---|---|
| `clients.slots._BLANK_WIPE_TABLES` | switch into a blank/seed slot |
| `reset_all_state` | factory reset |
| `_seed_episodic_memory` | fixture load |

Client→client switching into a slot that already has `state.db` was never affected: the sqlite backup API truncates the destination to an exact copy of the source.

`reset_all_state` now pre-initializes both cache schemas before the DELETE pass, following the `monitoring_store.initialize_db` precedent eight lines above it. `_delete_all_rows` is not per-table existence-guarded and both caches create their table lazily, so without this a reset against a DB that had never served a briefing raised `no such table: briefing_narrative`. That regression was caught by the existing reset tests, not by the new ones.

## Don't trust the insight hash

The inline comment is deliberate. `build_insight_input_hash` covers role, `is_principal`, status, counters, availability and the UTC day — **not** person or company identity — and the cache key is `person_id`, a reused autoincrement PK. An outgoing principal and a freshly seeded incoming principal, both with no awaiting work on the same day, hash **identically**. That is ordinary steady state for a seeded slot, not a collision, and a future reader deciding whether the entry is needed should not conclude the hash self-guards.

## Tests

- `test_seed_slot_activation_clears_derived_caches` — behavioural; fails without the fix with the outgoing narrative surviving.
- `test_seed_episodic_memory_clears_derived_caches` — behavioural, covers the fixture-load path; proven to fail with the wipe disabled.
- `test_switch_preserves_outgoing_caches_in_its_slot` — pins the **ordering**. The wipe must happen after the outgoing client's `VACUUM INTO` save-back, or its cached narrative is destroyed rather than parked. The other tests cannot catch that, because no client is active in them so the save-back branch never runs.
- `test_wipe_lists_consume_the_shared_cache_constant` — guards against the three lists diverging again.

Full unit suite green (the only failures are the pre-existing local-only set documented in `CLAUDE.md`, unchanged from the baseline).

## Deliberately left open

`dynamic_workflows` and `eval_scenarios` are **also** client-scoped — the non-blank path already swaps them with the whole DB — and on the blank path the outgoing client's workflow definitions stay registered **and active** (`list_definitions(active_only=True)`), runnable against the incoming client's data, with full bodies exposed via `/workflows`.

They are not in the wipe list because they are authored rather than derived, and `snapshot_user_state` (the first-activation branch, when no client is active) captures only profile/docs/`memory.json`/people/departments. Wiping without capturing them there first would irrecoverably delete the operator's own work. The fix is to extend that snapshot, then wipe — a separate change. Both tables are empty on current installs. Recorded in `architecture-facts.yaml` rather than left implicit.

Also graded there as correctly **not** wiped: `generated_fixtures` (operator-level, `_GLOBAL_TABLES`) and `architecture_sections` (repo-derived, keyed by a hash of the facts file).

---

Independent of #72 — verified by developing this branch on `main` without the encoding fix; the targeted suites pass on that base.