### PR TITLE
Fix Python 3.13-only kwarg in the encoding-contract test guard

### DIFF
--- a/packages/core/tests/unit/test_client_slots.py
+++ b/packages/core/tests/unit/test_client_slots.py
@@ -428,10 +428,14 @@ async def test_generated_slot_pins_encoding_on_every_text_write(
             offenders.append(f"write_text: {self.name}")
         return real_write(self, data, encoding=encoding or "utf-8", errors=errors, newline=newline)
 
-    def guarded_read(self, encoding=None, errors=None, newline=None):  # type: ignore[no-untyped-def]
+    # No `newline` here: Path.read_text only accepts it on Python 3.13+, and CI
+    # runs 3.11 — forwarding it unconditionally would TypeError the moment a
+    # read_text call enters the guarded path (exactly the regression this guard
+    # exists to catch). **kwargs keeps the forwarding correct on every version.
+    def guarded_read(self, encoding=None, **kwargs):  # type: ignore[no-untyped-def]
         if encoding is None:
             offenders.append(f"read_text: {self.name}")
-        return real_read(self, encoding=encoding or "utf-8", errors=errors, newline=newline)
+        return real_read(self, encoding=encoding or "utf-8", **kwargs)
 
     monkeypatch.setattr(Path, "write_text", guarded_write)
     monkeypatch.setattr(Path, "read_text", guarded_read)


### PR DESCRIPTION
## What & why

Maintainer follow-up to #72, fixing the one defect flagged in its review. The `guarded_read` helper in `test_generated_slot_pins_encoding_on_every_text_write` forwarded `newline=` to `Path.read_text`, which only accepts that parameter on Python 3.13+. CI runs 3.11, where that call raises `TypeError`. The test is green today only because no `read_text` call is reached on the guarded path — but the moment one appears (exactly the regression the guard exists to catch), the test would fail with a confusing `TypeError` instead of its intended assertion.

## How it works

`guarded_read` now takes `**kwargs` and forwards them, which is correct on every supported Python version: on 3.11 nothing passes `newline` (the real method would reject it anyway), and on 3.13+ a caller's `newline` still reaches the real method. Verified the original defect on the repo's own interpreter (`Path.read_text(newline=None)` → `TypeError` on 3.11) and the slot test suite passes with the change (18 tests).

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] Tests added/updated for new behavior (`pytest packages/core/tests/unit/`) — this is itself a test fix; `test_client_slots.py` passes (18 tests)
- [x] `ruff check` and `mypy` pass (`make lint`)
- [ ] UI builds if touched — UI not touched
- [ ] Eval scenarios added for a new agent or prompt change — no agent/prompt change
- [ ] Architecture docs updated if a documented topic changed — no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Deliberately minimal: the review of #72 also noted the `try/except` branch in `_rebuild_vector_state` lacks test coverage and that a total vector-store outage degrades silently; those are left for a separate change so this stays a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD)_