### PR TITLE
Document the hosted-gateway use of the LOCAL_* provider settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,9 @@ OPENROUTER_API_KEY=
 # Route selected model slugs to a local OpenAI-compatible server (Ollama,
 # LM Studio, vLLM, llama.cpp, …) instead of the Anthropic API. Off by default;
 # a fresh checkout behaves identically to before.
+# Also works with HOSTED OpenAI-compatible gateways: point LOCAL_BASE_URL at
+# the gateway's /v1 endpoint, set LOCAL_API_KEY, and list its model slugs in
+# LOCAL_MODELS. See README → "Using a hosted OpenAI-compatible gateway".
 LOCAL_MODELS_ENABLED=false
 # Base URL of the local server, INCLUDING the version path. Required when
 # LOCAL_MODELS_ENABLED=true.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,31 @@ pick a model that's strong at it (e.g. Llama 3.3 70B, Qwen2.5) — small models
 may route poorly. `LOCAL_API_KEY` is only needed if your server (vLLM, or a
 gateway) requires a bearer token; Ollama and LM Studio need none.
 
+### Using a hosted OpenAI-compatible gateway
+
+The `LOCAL_*` settings are not limited to localhost — the same recipe works with
+any **hosted** OpenAI-compatible endpoint (an aggregator or inference gateway):
+
+```bash
+LOCAL_MODELS_ENABLED=true
+LOCAL_BASE_URL=https://gateway.example.com/v1
+LOCAL_API_KEY=your-gateway-key
+LOCAL_MODELS=vendor/model-a,vendor/model-b
+```
+
+The listed slugs are sent to the gateway verbatim and appear in the Council UI
+dropdown, exactly like local slugs. Gateways that speak OpenRouter's request
+format and model namespace can alternatively be used through the OpenRouter
+path (`OPENROUTER_ENABLED=true` + `OPENROUTER_API_KEY` +
+`OPENROUTER_BASE_URL=https://gateway.example.com/v1`), which keeps that path's
+Claude-name translation and feature handling.
+
+The local-model caveats above apply to the `LOCAL_*` path unchanged, plus one
+that matters more for hosted endpoints: everything the Executive processes —
+company profile, documents, conversations — is sent to whichever endpoint you
+configure here. Point these settings only at a provider you trust with that
+data.
+
 ## Adding a New Specialist Agent
 
 1. Create `packages/core/openexecutive/agents/your_agent.py` extending `BaseAgent`


### PR DESCRIPTION
## What & why

The `LOCAL_*` settings group is already a fully generic OpenAI-compatible backend: any base URL (not just localhost), an optional bearer token, and a model-slug list that gets surfaced in the Council UI dropdown and counted by the boot availability check. The "local" naming hides that, which is why vendor PRs keep offering branded provider integrations for capability the project already ships. This documents the hosted-gateway recipe so users (and future PR authors) can find it.

## How it works

- **README**: a new "Using a hosted OpenAI-compatible gateway" subsection under "Running on Local Models" with the `LOCAL_*` recipe for hosted endpoints, a note that OpenRouter-compatible gateways can alternatively use `OPENROUTER_BASE_URL` (keeping that path's Claude-name translation and feature handling), and an explicit warning that everything the Executive processes is sent to whichever endpoint is configured.
- **.env.example**: three comment lines in the existing LOCAL block cross-referencing the README section.

Claims were verified against `providers/registry.py` (`get_provider` routing rules, `allowed_models()` dropdown behavior) and `config.py` (`_validate_provider_available`) before writing. Docs only — no behavior change.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders (docs only)
- [ ] Tests added/updated for new behavior — no behavior change
- [x] `ruff check` and `mypy` pass (`make lint`) — unaffected, sanity-checked
- [ ] UI builds if touched — UI not touched
- [ ] Eval scenarios added for a new agent or prompt change — none
- [ ] Architecture docs updated if a documented topic changed — no endpoint, integration, routing, or caching behavior changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

The example uses a neutral `gateway.example.com` placeholder rather than naming any specific vendor — deliberately, so the docs describe a capability rather than endorse a provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD)_