### PR TITLE
fix: remove silent install fallback that masked missing README dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install uv
 RUN uvx --from git+https://github.com/SenteLabsAI/extensible-mcp extensible-mcp --help \
     || true
 
-COPY packages/core/pyproject.toml packages/core/uv.lock* ./
+COPY packages/core/pyproject.toml packages/core/uv.lock* packages/core/README.md ./
 RUN uv pip install --system -r pyproject.toml 2>/dev/null || uv pip install --system .
 
 # Bake the embedding model the MCP gateway loads at startup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,12 @@ RUN pip install uv
 RUN uvx --from git+https://github.com/SenteLabsAI/extensible-mcp extensible-mcp --help \
     || true
 
-COPY packages/core/pyproject.toml packages/core/uv.lock* packages/core/README.md ./
-RUN uv pip install --system -r pyproject.toml 2>/dev/null || uv pip install --system .
+COPY packages/core/pyproject.toml packages/core/uv.lock* ./
+# No fallback: this install has always succeeded on its own, and a silent
+# fallback here previously masked failures while also needing README.md
+# copied into this layer — which busts the cache (full dep install + baked
+# embedding models below) on every README edit. Let a real break fail loudly.
+RUN uv pip install --system -r pyproject.toml
 
 # Bake the embedding model the MCP gateway loads at startup
 # (sentence-transformers/all-MiniLM-L6-v2). Without this the ~90 MB model is

--- a/packages/ui/src/auth.ts
+++ b/packages/ui/src/auth.ts
@@ -94,6 +94,13 @@ function auditAuth(
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // Middleware runs on the Edge runtime, where @auth/core's env-based
+  // trustHost detection (reading process.env.AUTH_TRUST_HOST dynamically)
+  // never sees the var even when it's set in the container — Next.js's Edge
+  // bundler only inlines *literal* process.env.X references, not the
+  // parameterized access @auth/core uses internally. A literal flag here is
+  // the only reliable way to satisfy self-hosted deployments.
+  trustHost: true,
   providers: [Google],
   // 24h JWT TTL. Defence in depth alongside the `authorized` re-check
   // below — a session that somehow drifts out of sync with the roster

--- a/packages/ui/src/auth.ts
+++ b/packages/ui/src/auth.ts
@@ -94,13 +94,6 @@ function auditAuth(
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  // Middleware runs on the Edge runtime, where @auth/core's env-based
-  // trustHost detection (reading process.env.AUTH_TRUST_HOST dynamically)
-  // never sees the var even when it's set in the container — Next.js's Edge
-  // bundler only inlines *literal* process.env.X references, not the
-  // parameterized access @auth/core uses internally. A literal flag here is
-  // the only reliable way to satisfy self-hosted deployments.
-  trustHost: true,
   providers: [Google],
   // 24h JWT TTL. Defence in depth alongside the `authorized` re-check
   // below — a session that somehow drifts out of sync with the roster


### PR DESCRIPTION
## What & why

`docker/Dockerfile`'s early dependency layer had a silent fallback: `uv pip install --system -r pyproject.toml 2>/dev/null || uv pip install --system .`. The fallback path needs `packages/core/README.md` present (declared via `readme = "README.md"` in `pyproject.toml`), which wasn't copied into that layer.

An earlier version of this PR fixed it by adding README.md to that COPY line — but per review, that's the wrong layer to touch: it's the heaviest one (full dependency install + baked embedding models), so every README edit would bust that cache and trigger a full rebuild.

## How it works

Remove the fallback and its `2>/dev/null` suppression entirely. The primary `uv pip install --system -r pyproject.toml` install has always worked on its own — `pyproject.toml` declares a static PEP 621 dependency list, so `-r pyproject.toml` never invokes the build backend or touches the readme field. A real break in that install should fail the build loudly, not fall through silently.

Verified this is more than a cache optimization: I reconstructed the file set the fallback would have seen if README.md had been added to that early layer (pyproject.toml + uv.lock + README, no source tree yet — that's copied later at line 78). `uv pip install --system .` in that state builds successfully but produces an **empty** `openexecutive` distribution (just dist-info metadata, zero modules) — the `openexecutive` console script would `ImportError` at runtime. So the fallback wasn't just cache-unfriendly, it was one dependency hiccup away from silently shipping a broken image.

Verified the removal doesn't break the build: full `docker build -f docker/Dockerfile .` completes successfully end to end, including the later `uv pip install --system --no-deps .` step (line ~86) that installs the local package after the full source — including README.md — has been copied.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] `ruff check` and `mypy` pass (no Python changed)
- [x] UI builds if touched — n/a, no UI files in this PR
- [ ] Tests — n/a, Dockerfile-only change, verified via an actual image build
- [ ] Eval scenarios — n/a, no agent/prompt change
- [ ] Architecture docs — n/a, no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Split from the original PR per feedback — the unrelated `auth.ts` trustHost fix now lives in its own PR.

Unrelated finding while verifying this, for your backlog rather than in scope here: `uv pip install -r pyproject.toml` doesn't honor `uv.lock` at all (it ignores lockfiles by design), so this layer installs floating `>=` versions rather than the pinned ones — e.g. the lock pins `transformers 5.10.1`/`torch 2.13.0`, but a live resolution today pulls `transformers 5.16.1`/`torch 2.14.0`. Pre-existing on both the old primary and old fallback paths, so this PR doesn't change that behavior — just flagging it since I was in here anyway. `uv sync --frozen` or `uv export --frozen | uv pip install -r -` would close it if it's worth a follow-up.