### PR TITLE
Document web search discoverability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,9 +129,11 @@ HONCHO_PREFETCH_TIMEOUT_S=3.0
 # OPENROUTER_REFERER=https://your-deployment.example.com
 # OPENROUTER_TIMEOUT_S=180.0
 
-# Web search — Anthropic's native server-side web_search tool. Off by default
-# since each search is billed separately. Enable to let the Executive look up
-# live facts (market data, news, regulatory changes, competitor moves).
+# Web search — Anthropic's native server-side web_search tool. The application
+# default is ON (unset means enabled); this file ships it off so a fresh setup
+# incurs no per-search charges until you opt in. Set true to let the Executive
+# and specialists combine your uploaded documents with live lookups (market
+# data, news, regulatory changes, competitor moves).
 ENABLE_WEB_SEARCH=false
 WEB_SEARCH_MAX_USES=5
 # Optional allowlist OR blocklist (comma-separated bare domains, no scheme).

--- a/README.md
+++ b/README.md
@@ -316,12 +316,22 @@ the app refuses to start.
 | `HONCHO_ENABLED` | No | `false` | Per-person memory layer ([honcho.dev](https://honcho.dev)) — a peer card shared across all channels |
 | `HONCHO_API_KEY` | No | — | Required when `HONCHO_ENABLED=true` |
 | `HONCHO_BASE_URL` | No | — | Self-hosted Honcho endpoint |
+| `ENABLE_WEB_SEARCH` | No | `true`² | Let the Executive and specialists answer with live web results (news, market data, competitor moves) alongside your uploaded documents |
+| `WEB_SEARCH_MAX_USES` | No | `2` | Max billed searches per agent per turn |
 
 See [.env.example](.env.example) for the full list.
 
 > ¹ `ANTHROPIC_API_KEY` is required only when you serve Claude models directly.
 > It can be omitted entirely if you run on local models (`LOCAL_MODELS_ENABLED`)
 > or route through OpenRouter (`OPENROUTER_ENABLED`).
+
+> ² The application default is on, but **[.env.example](.env.example) ships
+> `ENABLE_WEB_SEARCH=false`** so a fresh setup incurs no per-search charges —
+> if the agents tell you they can't search the web or read the news, flip it
+> to `true` in your `.env` and restart. Uses Anthropic's server-side
+> `web_search` tool, so it applies to Claude models (local models can't use
+> it). `WEB_SEARCH_ALLOWED_DOMAINS` / `WEB_SEARCH_BLOCKED_DOMAINS` scope where
+> it may look (set at most one).
 
 ## Running on Local Models
 


### PR DESCRIPTION
## What & why

Issue #79 asked whether the agents can use web search. They can — it's Anthropic's server-side `web_search` tool, wired into the Executive chat path, and the code defaults it **on**. But `.env.example` ships `ENABLE_WEB_SEARCH=false` (a deliberate choice: each search is billed), its comment wrongly claims the feature is "off by default," and the README env table has no row for it at all. So anyone who set up via the documented copy-`.env.example` path has web search silently disabled with no breadcrumb to find it — exactly the experience #79 reports.

## How it works

- **README**: `ENABLE_WEB_SEARCH` and `WEB_SEARCH_MAX_USES` rows in the env table, plus a footnote explaining that the example file ships it off to avoid surprise per-search charges, how to turn it on, that it applies to Claude models (local models can't use it), and the domain allow/blocklist knobs.
- **.env.example**: correct the comment — the application default is on; this file ships it off so a fresh setup incurs no charges until the user opts in.

Claims verified against `config.py` (`enable_web_search` default `True`) and `orchestrator/executive.py` (`build_web_search_tool` attachment). Docs only — no behavior change; the example file continues to ship the flag off.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders (docs only)
- [ ] Tests added/updated for new behavior — no behavior change
- [x] `ruff check` and `mypy` pass (`make lint`) — unaffected
- [ ] UI builds if touched — UI not touched
- [ ] Eval scenarios added for a new agent or prompt change — none
- [ ] Architecture docs updated if a documented topic changed — `architecture-facts.yaml` already correctly documents the code default; no behavior changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Deliberately keeps `ENABLE_WEB_SEARCH=false` in the example file — the goal is discoverability, not changing the cost posture for fresh setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD)_