### PR TITLE
fix(onboarding): ARR/burn-rate regex crash and retryable final step (closes #84, supersedes #56)

### DIFF
--- a/packages/core/openexecutive/api/models.py
+++ b/packages/core/openexecutive/api/models.py
@@ -63,15 +63,20 @@ class ChatResponse(BaseModel):
     session_id: str
 
 
+# Wizard answers are a sentence or two, or a short one-per-line list. The
+# free-text parsers in onboarding/wizard.py run regexes over this, so it is
+# a safety bound on event-loop time, not only a UX choice — do not raise it
+# without re-checking the parser benchmarks in test_onboarding_wizard_arr_parse.
 ONBOARD_ANSWER_MAX_CHARS = 10_000
 
 
 class OnboardAnswerRequest(BaseModel):
     session_id: str
-    # Wizard answers are a sentence or two, or a short one-per-line list.
-    # The free-text parsers in onboarding/wizard.py run regexes over this,
-    # so bound it rather than let one request pin the event loop.
-    answer: str = Field(max_length=ONBOARD_ANSWER_MAX_CHARS)
+    # Bounded to ONBOARD_ANSWER_MAX_CHARS in the route rather than with
+    # Field(max_length=...): FastAPI's default validation error echoes the
+    # rejected input back in the response body, and wizard answers include
+    # financials the UI promises are stored locally only.
+    answer: str
 
 
 class OnboardStatusResponse(BaseModel):

--- a/packages/core/openexecutive/api/models.py
+++ b/packages/core/openexecutive/api/models.py
@@ -63,9 +63,15 @@ class ChatResponse(BaseModel):
     session_id: str
 
 
+ONBOARD_ANSWER_MAX_CHARS = 10_000
+
+
 class OnboardAnswerRequest(BaseModel):
     session_id: str
-    answer: str
+    # Wizard answers are a sentence or two, or a short one-per-line list.
+    # The free-text parsers in onboarding/wizard.py run regexes over this,
+    # so bound it rather than let one request pin the event loop.
+    answer: str = Field(max_length=ONBOARD_ANSWER_MAX_CHARS)
 
 
 class OnboardStatusResponse(BaseModel):

--- a/packages/core/openexecutive/api/routes/onboarding.py
+++ b/packages/core/openexecutive/api/routes/onboarding.py
@@ -7,7 +7,11 @@ import uuid
 
 from fastapi import APIRouter, HTTPException
 
-from openexecutive.api.models import OnboardAnswerRequest, OnboardStatusResponse
+from openexecutive.api.models import (
+    ONBOARD_ANSWER_MAX_CHARS,
+    OnboardAnswerRequest,
+    OnboardStatusResponse,
+)
 from openexecutive.onboarding.wizard import (
     TOTAL_STEPS,
     WizardState,
@@ -62,6 +66,11 @@ async def submit_answer(body: OnboardAnswerRequest) -> OnboardStatusResponse:
         raise HTTPException(status_code=404, detail="Onboarding session not found")
     if state.completed:
         raise HTTPException(status_code=400, detail="Onboarding already completed")
+    if len(body.answer) > ONBOARD_ANSWER_MAX_CHARS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Answer is too long (limit {ONBOARD_ANSWER_MAX_CHARS:,} characters).",
+        )
 
     # process_answer mutates the stored state in place. Keep a snapshot so
     # a failed profile build on the final answer can be rolled back —

--- a/packages/core/openexecutive/api/routes/onboarding.py
+++ b/packages/core/openexecutive/api/routes/onboarding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import uuid
 
@@ -62,13 +63,28 @@ async def submit_answer(body: OnboardAnswerRequest) -> OnboardStatusResponse:
     if state.completed:
         raise HTTPException(status_code=400, detail="Onboarding already completed")
 
+    # process_answer mutates the stored state in place. Keep a snapshot so
+    # a failed profile build on the final answer can be rolled back —
+    # otherwise the session is stuck at completed=True and every retry
+    # hits the 400 above, forcing the user to restart onboarding.
+    snapshot = copy.deepcopy(state)
     state = process_answer(state, body.answer)
-    _wizard_sessions[body.session_id] = state
 
     if state.completed:
         from openexecutive.onboarding.profile_builder import build_and_save_profile
 
-        build_and_save_profile(state)
+        try:
+            build_and_save_profile(state)
+        except Exception as exc:
+            logger.exception("onboarding: profile build failed on the final answer")
+            _wizard_sessions[body.session_id] = snapshot
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Could not build the company profile from your answers. "
+                    "Please rephrase your last answer and try again."
+                ),
+            ) from exc
 
         # Fire the watchlist-research workflow once at onboarding
         # completion so the principal's first /today after install
@@ -86,6 +102,8 @@ async def submit_answer(body: OnboardAnswerRequest) -> OnboardStatusResponse:
             # Auto-cleanup so the set doesn't grow unboundedly across
             # the process lifetime.
             task.add_done_callback(_background_research_tasks.discard)
+
+    _wizard_sessions[body.session_id] = state
 
     question = get_current_question(state) if not state.completed else None
     progress = state.get_progress()

--- a/packages/core/openexecutive/api/routes/onboarding.py
+++ b/packages/core/openexecutive/api/routes/onboarding.py
@@ -76,13 +76,20 @@ async def submit_answer(body: OnboardAnswerRequest) -> OnboardStatusResponse:
         try:
             build_and_save_profile(state)
         except Exception as exc:
-            logger.exception("onboarding: profile build failed on the final answer")
+            # Type name only: a pydantic ValidationError's str() embeds the
+            # offending input, and the wizard answers include financials
+            # the UI promises are "stored locally only".
+            logger.error(
+                "onboarding: profile build failed on the final answer (%s)",
+                type(exc).__name__,
+            )
             _wizard_sessions[body.session_id] = snapshot
             raise HTTPException(
                 status_code=422,
                 detail=(
                     "Could not build the company profile from your answers. "
-                    "Please rephrase your last answer and try again."
+                    "Rephrase your last answer and try again, or restart "
+                    "onboarding if an earlier answer is the problem."
                 ),
             ) from exc
 

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -79,7 +79,10 @@ class CompanyProfile(BaseModel):
         return cls.model_validate(company_data)
 
     def save_to_yaml(self, path: Path | str) -> None:
-        path = Path(path)
+        # Resolve first so a symlinked profile path (a common deployment
+        # pattern for COMPANY_PROFILE_PATH) is written at its target and the
+        # link survives, instead of being replaced by a regular file.
+        path = Path(path).resolve()
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {"company": self.model_dump()}
         # Write-then-rename so a failure mid-dump (disk full, unrepresentable
@@ -92,33 +95,35 @@ class CompanyProfile(BaseModel):
         #   os.fdopen) keeps the explicit-encoding contract visible.
         # - A random component plus O_EXCL: two processes on one volume
         #   (both PID 1 in their containers) cannot collide.
+        # - The temp is always created 0600 and only widened to the
+        #   destination's mode after fsync, right before the rename. A
+        #   crash leftover (SIGKILL, OOM) is therefore private clutter,
+        #   never a readable copy of the financials. There is no sweep of
+        #   leftovers: one cannot be told apart from another process's
+        #   in-flight file, and unlinking that makes its rename fail.
         # - The destination's mode is carried over: rename creates a new
         #   inode, so a file an operator chmod'd 0600 would otherwise
-        #   silently revert to the umask default.
+        #   silently revert to the umask default. A symlink's own mode
+        #   (always 0777) is never used.
         # - fsync file and directory: a hard crash between write and
         #   rename must not leave a zero-length profile.
-        # There is deliberately no sweep of stale temps: a sweep cannot
-        # tell a crashed writer's leftover from another process's
-        # in-flight file, and unlinking the latter makes its rename fail.
-        # A leftover is 0600 clutter, not a leak.
         tmp_path = path.with_name(f".tmp-{os.getpid()}-{secrets.token_hex(4)}-{path.name}")
         existing_mode: int | None = None
         with contextlib.suppress(OSError):
-            # lstat: never take the mode from a symlink's target.
-            existing_mode = stat.S_IMODE(path.lstat().st_mode)
+            st = path.lstat()
+            if not stat.S_ISLNK(st.st_mode):
+                existing_mode = stat.S_IMODE(st.st_mode)
 
         def _exclusive(p: str, flags: int) -> int:
-            return os.open(p, flags | os.O_EXCL, 0o600 if existing_mode is None else existing_mode)
+            return os.open(p, flags | os.O_EXCL, 0o600)
 
         try:
             with open(tmp_path, "w", encoding="utf-8", opener=_exclusive) as f:
-                if existing_mode is not None and hasattr(os, "fchmod"):
-                    # os.open applies the umask; fchmod restores the exact
-                    # mode the destination had. Unix only.
-                    os.fchmod(f.fileno(), existing_mode)
                 yaml.dump(data, f, default_flow_style=False, sort_keys=True)
                 f.flush()
                 os.fsync(f.fileno())
+                if existing_mode is not None and hasattr(os, "fchmod"):
+                    os.fchmod(f.fileno(), existing_mode)
             os.replace(tmp_path, path)
             with contextlib.suppress(OSError):
                 dir_fd = os.open(path.parent, os.O_RDONLY)

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -81,8 +81,14 @@ class CompanyProfile(BaseModel):
     def save_to_yaml(self, path: Path | str) -> None:
         # Resolve first so a symlinked profile path (a common deployment
         # pattern for COMPANY_PROFILE_PATH) is written at its target and the
-        # link survives, instead of being replaced by a regular file.
-        path = Path(path).resolve()
+        # link survives, instead of being replaced by a regular file. A
+        # symlink loop raises RuntimeError on 3.11 and OSError on 3.13; fall
+        # back to the unresolved path and let the open() below report it.
+        path = Path(path)
+        try:
+            path = path.resolve()
+        except (OSError, RuntimeError):
+            path = path.absolute()
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {"company": self.model_dump()}
         # Write-then-rename so a failure mid-dump (disk full, unrepresentable

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -97,22 +97,24 @@ class CompanyProfile(BaseModel):
         #   silently revert to the umask default.
         # - fsync file and directory: a hard crash between write and
         #   rename must not leave a zero-length profile.
-        # Stale temps from an earlier crash are swept first so a
-        # 0644 copy of the financials never lingers in company/.
-        for stale in path.parent.glob(f".tmp-*-{path.name}"):
-            with contextlib.suppress(OSError):
-                stale.unlink()
+        # There is deliberately no sweep of stale temps: a sweep cannot
+        # tell a crashed writer's leftover from another process's
+        # in-flight file, and unlinking the latter makes its rename fail.
+        # A leftover is 0600 clutter, not a leak.
         tmp_path = path.with_name(f".tmp-{os.getpid()}-{secrets.token_hex(4)}-{path.name}")
         existing_mode: int | None = None
         with contextlib.suppress(OSError):
-            existing_mode = stat.S_IMODE(path.stat().st_mode)
+            # lstat: never take the mode from a symlink's target.
+            existing_mode = stat.S_IMODE(path.lstat().st_mode)
 
         def _exclusive(p: str, flags: int) -> int:
             return os.open(p, flags | os.O_EXCL, 0o600 if existing_mode is None else existing_mode)
 
         try:
             with open(tmp_path, "w", encoding="utf-8", opener=_exclusive) as f:
-                if existing_mode is not None:
+                if existing_mode is not None and hasattr(os, "fchmod"):
+                    # os.open applies the umask; fchmod restores the exact
+                    # mode the destination had. Unix only.
                     os.fchmod(f.fileno(), existing_mode)
                 yaml.dump(data, f, default_flow_style=False, sort_keys=True)
                 f.flush()

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -78,8 +80,21 @@ class CompanyProfile(BaseModel):
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         data = {"company": self.model_dump()}
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=True)
+        # Write-then-rename so a failure mid-dump (disk full, unrepresentable
+        # value) can never leave a truncated profile behind: every other
+        # subsystem loads this file, and callers such as the onboarding
+        # route roll back on failure assuming the old profile survived.
+        # Plain open() (not mkstemp) so the temp file gets the normal umask
+        # permissions the final file would have had.
+        tmp_path = path.with_name(f".tmp-{os.getpid()}-{path.name}")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                yaml.dump(data, f, default_flow_style=False, sort_keys=True)
+            os.replace(tmp_path, path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
 
     def to_prompt_block(self) -> str:
         if not self.name:

--- a/packages/core/openexecutive/memory/company_profile.py
+++ b/packages/core/openexecutive/memory/company_profile.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import os
+import secrets
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -84,13 +86,44 @@ class CompanyProfile(BaseModel):
         # value) can never leave a truncated profile behind: every other
         # subsystem loads this file, and callers such as the onboarding
         # route roll back on failure assuming the old profile survived.
-        # Plain open() (not mkstemp) so the temp file gets the normal umask
-        # permissions the final file would have had.
-        tmp_path = path.with_name(f".tmp-{os.getpid()}-{path.name}")
+        #
+        # - O_EXCL via `opener`: the temp name is created fresh and never
+        #   follows a pre-planted symlink. Going through open() (not
+        #   os.fdopen) keeps the explicit-encoding contract visible.
+        # - A random component plus O_EXCL: two processes on one volume
+        #   (both PID 1 in their containers) cannot collide.
+        # - The destination's mode is carried over: rename creates a new
+        #   inode, so a file an operator chmod'd 0600 would otherwise
+        #   silently revert to the umask default.
+        # - fsync file and directory: a hard crash between write and
+        #   rename must not leave a zero-length profile.
+        # Stale temps from an earlier crash are swept first so a
+        # 0644 copy of the financials never lingers in company/.
+        for stale in path.parent.glob(f".tmp-*-{path.name}"):
+            with contextlib.suppress(OSError):
+                stale.unlink()
+        tmp_path = path.with_name(f".tmp-{os.getpid()}-{secrets.token_hex(4)}-{path.name}")
+        existing_mode: int | None = None
+        with contextlib.suppress(OSError):
+            existing_mode = stat.S_IMODE(path.stat().st_mode)
+
+        def _exclusive(p: str, flags: int) -> int:
+            return os.open(p, flags | os.O_EXCL, 0o600 if existing_mode is None else existing_mode)
+
         try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
+            with open(tmp_path, "w", encoding="utf-8", opener=_exclusive) as f:
+                if existing_mode is not None:
+                    os.fchmod(f.fileno(), existing_mode)
                 yaml.dump(data, f, default_flow_style=False, sort_keys=True)
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, path)
+            with contextlib.suppress(OSError):
+                dir_fd = os.open(path.parent, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
         except BaseException:
             with contextlib.suppress(OSError):
                 os.unlink(tmp_path)

--- a/packages/core/openexecutive/onboarding/profile_builder.py
+++ b/packages/core/openexecutive/onboarding/profile_builder.py
@@ -61,8 +61,12 @@ def _save_wizard_people(answers: dict) -> None:  # type: ignore[type-arg]
                     scopes.append(AuthorityScope(tok))
             if scopes:
                 set_authority_scope(pid, scopes)
-    except Exception:
-        logger.warning("_save_wizard_people failed — skipping people creation", exc_info=True)
+    except Exception as exc:
+        # Type name only: the traceback would carry the wizard's org-chart
+        # answers (names, emails, handles) into the log stream.
+        logger.warning(
+            "_save_wizard_people failed (%s) — skipping people creation", type(exc).__name__
+        )
 
 
 def load_or_create_profile(path: Path | str | None = None) -> CompanyProfile:

--- a/packages/core/openexecutive/onboarding/wizard.py
+++ b/packages/core/openexecutive/onboarding/wizard.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 WIZARD_STEPS = [
     {
@@ -195,10 +198,22 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         profile["target_customer"] = {"profile": text, "pain_points": []}
         import re
 
-        arr_match = re.search(r"\$?([\d,]+)\s*[Mm]", text)
+        # The capture must START with a digit and the M must end a word.
+        # `[\d,]+` alone matched a bare comma, so any answer with a comma
+        # before an m-word — "Consultoría estratégica, marketing y
+        # operaciones" — captured "," and crashed the whole wizard on
+        # float(""). Requiring \b also stops "300 clientes, marketing"
+        # from being read as $300M.
+        arr_match = re.search(r"\$?(\d[\d,]*)\s*[Mm]\b", text)
         if arr_match:
             val = arr_match.group(1).replace(",", "")
-            profile["annual_revenue_arr"] = float(val) * 1_000_000
+            # Defensive: this is a best-effort parse of free text, so a
+            # surprising input must never take down onboarding. Skipping
+            # the field costs one profile value; raising costs the run.
+            try:
+                profile["annual_revenue_arr"] = float(val) * 1_000_000
+            except ValueError:
+                logger.warning("onboarding: could not parse ARR from %r", text[:80])
 
     if "competitive_landscape" in answers:
         text = answers["competitive_landscape"]

--- a/packages/core/openexecutive/onboarding/wizard.py
+++ b/packages/core/openexecutive/onboarding/wizard.py
@@ -198,13 +198,15 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         profile["target_customer"] = {"profile": text, "pain_points": []}
         import re
 
-        # The capture must START with a digit and the M must end a word.
-        # `[\d,]+` alone matched a bare comma, so any answer with a comma
-        # before an m-word — "Consultoría estratégica, marketing y
-        # operaciones" — captured "," and crashed the whole wizard on
-        # float(""). Requiring \b also stops "300 clientes, marketing"
-        # from being read as $300M.
-        arr_match = re.search(r"\$?(\d[\d,]*)\s*[Mm]\b", text)
+        # The capture must START with a digit and the magnitude must end a
+        # word. `[\d,]+` alone matched a bare comma, so any answer with a
+        # comma before an m-word — "IT, marketing and video agency" —
+        # captured "," and crashed the whole wizard on float(""). The \b
+        # also stops "300 clients, marketing" from being read as $300M and
+        # "$5 minimum" from becoming $5M. The alternation keeps "M", "MM"
+        # and "million" all parsing, since a bare `[Mm]\b` silently dropped
+        # "roughly 50 million" and "$50MM".
+        arr_match = re.search(r"\$?(\d[\d,]*)\s*(?:[Mm]{1,2}|[Mm]illion)\b", text)
         if arr_match:
             val = arr_match.group(1).replace(",", "")
             # Defensive: this is a best-effort parse of free text, so a
@@ -262,14 +264,22 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         import re
 
         text = answers["financials"]
-        burn_match = re.search(r"\$?([\d,]+)\s*[Kk]?\s*(?:monthly|/month|per month|burn)", text)
+        # Same digit-first rule as the ARR parse above: `[\d,]+` matched a
+        # bare comma, so "runway is fine, monthly costs are low" captured
+        # "," and crashed on float("").
+        burn_match = re.search(
+            r"\$?(\d[\d,]*)\s*[Kk]?\s*(?:monthly|/month|per month|burn)", text
+        )
         runway_match = re.search(r"(\d+)\s*month", text)
 
         fin: dict[str, Any] = {}
         if burn_match:
             val = burn_match.group(1).replace(",", "")
             multiplier = 1000 if "k" in text[burn_match.start():burn_match.end()].lower() else 1
-            fin["burn_rate_monthly"] = float(val) * multiplier
+            try:
+                fin["burn_rate_monthly"] = float(val) * multiplier
+            except ValueError:
+                logger.warning("onboarding: could not parse burn rate from %r", text[:80])
         if runway_match:
             fin["runway_months"] = float(runway_match.group(1))
         profile["financials"] = fin

--- a/packages/core/openexecutive/onboarding/wizard.py
+++ b/packages/core/openexecutive/onboarding/wizard.py
@@ -181,7 +181,8 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         import re
 
         text = answers["headcount_and_founding"]
-        nums = re.findall(r"\d+", text)
+        # Bounded so int() can never hit its digit limit on a hostile run.
+        nums = re.findall(r"\d{1,9}", text)
         if nums:
             if len(nums) >= 2:
                 profile["headcount"] = int(nums[0])
@@ -278,7 +279,9 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         burn_match = re.search(
             r"\$?(?<![\d,])(\d[\d,]*)\s*(?:[Kk]\s*)?(?:monthly|/month|per month|burn)", text
         )
-        runway_match = re.search(r"(\d+)\s*month", text)
+        # Same lookbehind as the other two: without it every digit of a
+        # long run is a candidate start and the search is quadratic.
+        runway_match = re.search(r"(?<!\d)(\d+)\s*month", text)
 
         fin: dict[str, Any] = {}
         if burn_match:

--- a/packages/core/openexecutive/onboarding/wizard.py
+++ b/packages/core/openexecutive/onboarding/wizard.py
@@ -205,17 +205,22 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         # also stops "300 clients, marketing" from being read as $300M and
         # "$5 minimum" from becoming $5M. The alternation keeps "M", "MM"
         # and "million" all parsing, since a bare `[Mm]\b` silently dropped
-        # "roughly 50 million" and "$50MM".
-        arr_match = re.search(r"\$?(\d[\d,]*)\s*(?:[Mm]{1,2}|[Mm]illion)\b", text)
+        # "roughly 50 million" and "$50MM". The lookbehind keeps the scan
+        # linear: without it every digit inside a long "1,1,1,…" run is a
+        # candidate start and the search goes quadratic on hostile input.
+        arr_match = re.search(
+            r"\$?(?<![\d,])(\d[\d,]*)\s*(?:[Mm]{1,2}|[Mm]illion)\b", text
+        )
         if arr_match:
             val = arr_match.group(1).replace(",", "")
             # Defensive: this is a best-effort parse of free text, so a
             # surprising input must never take down onboarding. Skipping
             # the field costs one profile value; raising costs the run.
+            # The answer text itself stays out of the log line.
             try:
                 profile["annual_revenue_arr"] = float(val) * 1_000_000
             except ValueError:
-                logger.warning("onboarding: could not parse ARR from %r", text[:80])
+                logger.warning("onboarding: could not parse ARR from the business-model answer")
 
     if "competitive_landscape" in answers:
         text = answers["competitive_landscape"]
@@ -268,7 +273,7 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         # bare comma, so "runway is fine, monthly costs are low" captured
         # "," and crashed on float("").
         burn_match = re.search(
-            r"\$?(\d[\d,]*)\s*[Kk]?\s*(?:monthly|/month|per month|burn)", text
+            r"\$?(?<![\d,])(\d[\d,]*)\s*[Kk]?\s*(?:monthly|/month|per month|burn)", text
         )
         runway_match = re.search(r"(\d+)\s*month", text)
 
@@ -279,7 +284,9 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
             try:
                 fin["burn_rate_monthly"] = float(val) * multiplier
             except ValueError:
-                logger.warning("onboarding: could not parse burn rate from %r", text[:80])
+                # Financials are promised "stored locally only" — keep the
+                # answer text out of the log stream.
+                logger.warning("onboarding: could not parse burn rate from the financials answer")
         if runway_match:
             fin["runway_months"] = float(runway_match.group(1))
         profile["financials"] = fin

--- a/packages/core/openexecutive/onboarding/wizard.py
+++ b/packages/core/openexecutive/onboarding/wizard.py
@@ -272,8 +272,11 @@ def build_profile_from_answers(answers: dict[str, Any]) -> dict[str, Any]:
         # Same digit-first rule as the ARR parse above: `[\d,]+` matched a
         # bare comma, so "runway is fine, monthly costs are low" captured
         # "," and crashed on float("").
+        # `(?:[Kk]\s*)?` rather than `[Kk]?\s*` after the first `\s*`: two
+        # adjacent `\s*` with an optional token between them let a long
+        # whitespace run be split quadratically many ways.
         burn_match = re.search(
-            r"\$?(?<![\d,])(\d[\d,]*)\s*[Kk]?\s*(?:monthly|/month|per month|burn)", text
+            r"\$?(?<![\d,])(\d[\d,]*)\s*(?:[Kk]\s*)?(?:monthly|/month|per month|burn)", text
         )
         runway_match = re.search(r"(\d+)\s*month", text)
 

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -135,3 +135,21 @@ def test_save_to_yaml_is_atomic(tmp_path: Path, monkeypatch):
 
     assert CompanyProfile.load_from_yaml(path).name == "Before"
     assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"], "temp file left behind"
+
+
+def test_save_to_yaml_preserves_mode_and_sweeps_stale_temps(tmp_path: Path):
+    """Rename creates a new inode; an operator's chmod must survive it."""
+    import os
+    import stat
+
+    path = tmp_path / "profile.yaml"
+    CompanyProfile(name="Before").save_to_yaml(path)
+    os.chmod(path, 0o600)
+    stale = tmp_path / ".tmp-1-deadbeef-profile.yaml"
+    stale.write_text("leftover from a crash", encoding="utf-8")
+
+    CompanyProfile(name="After").save_to_yaml(path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert CompanyProfile.load_from_yaml(path).name == "After"
+    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -140,49 +140,67 @@ def test_save_to_yaml_is_atomic(tmp_path: Path, monkeypatch):
 def test_save_to_yaml_preserves_mode(tmp_path: Path):
     """Rename creates a new inode; an operator's chmod must survive it.
 
-    0o664 rather than 0o600 on purpose: a fresh profile is already created
-    0o600, and 0o600 is umask-invariant, so it would exercise neither the
-    stat nor the fchmod that carry the mode across.
+    0o664 rather than 0o600 on purpose: the temp file is always created
+    0o600, so a mode equal to the default would pass even if the fchmod
+    that carries the destination's mode across were removed.
     """
     import os
     import stat
 
-    # Pin the umask: under 000, os.open(..., 0o664) alone would yield 0o664
-    # and the fchmod that carries the mode across would go unexercised.
-    old_umask = os.umask(0o022)
-    try:
-        path = tmp_path / "profile.yaml"
-        CompanyProfile(name="Before").save_to_yaml(path)
-        assert stat.S_IMODE(path.stat().st_mode) == 0o600, "fresh profile should be private"
-        os.chmod(path, 0o664)
+    path = tmp_path / "profile.yaml"
+    CompanyProfile(name="Before").save_to_yaml(path)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600, "fresh profile should be private"
+    os.chmod(path, 0o664)
 
-        CompanyProfile(name="After").save_to_yaml(path)
+    CompanyProfile(name="After").save_to_yaml(path)
 
-        assert stat.S_IMODE(path.stat().st_mode) == 0o664
-        assert CompanyProfile.load_from_yaml(path).name == "After"
-        assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
-    finally:
-        os.umask(old_umask)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o664
+    assert CompanyProfile.load_from_yaml(path).name == "After"
+    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
 
 
 def test_save_to_yaml_through_symlink_keeps_link_and_target_mode(tmp_path: Path):
-    """A symlinked profile path writes the target and never uses the link's 0777."""
+    """A symlinked profile path writes the target and never uses the link's 0777.
+
+    The target is chmod'd 0o640 (not the 0o600 default) so the test also
+    proves the mode carried across came from the target, not the link.
+    """
     import os
     import stat
 
     target = tmp_path / "volume" / "profile.yaml"
     target.parent.mkdir()
     CompanyProfile(name="Before").save_to_yaml(target)
+    os.chmod(target, 0o640)
     link = tmp_path / "profile.yaml"
     link.symlink_to(target)
 
     CompanyProfile(name="After").save_to_yaml(link)
 
     assert link.is_symlink(), "the symlink must survive the save"
-    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
     assert CompanyProfile.load_from_yaml(link).name == "After"
     assert [p.name for p in target.parent.iterdir()] == ["profile.yaml"]
-    assert not os.access(target, os.W_OK) or stat.S_IMODE(target.stat().st_mode) != 0o777
+
+
+def test_save_to_yaml_replaces_a_symlink_loop(tmp_path: Path):
+    """A looped symlink at the profile path is broken config, not a crash.
+
+    Path.resolve() raises RuntimeError on 3.11 for a loop; save_to_yaml must
+    fall back rather than let that escape (the profile-editor route has no
+    handler for it). The loop is replaced by a private regular file.
+    """
+    import stat
+
+    link = tmp_path / "profile.yaml"
+    link.symlink_to(link)
+
+    CompanyProfile(name="X").save_to_yaml(link)
+
+    assert not link.is_symlink()
+    assert stat.S_IMODE(link.stat().st_mode) == 0o600
+    assert CompanyProfile.load_from_yaml(link).name == "X"
+    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
 
 
 def test_concurrent_saves_do_not_break_each_other(tmp_path: Path):

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -147,16 +147,42 @@ def test_save_to_yaml_preserves_mode(tmp_path: Path):
     import os
     import stat
 
-    path = tmp_path / "profile.yaml"
-    CompanyProfile(name="Before").save_to_yaml(path)
-    assert stat.S_IMODE(path.stat().st_mode) == 0o600, "fresh profile should be private"
-    os.chmod(path, 0o664)
+    # Pin the umask: under 000, os.open(..., 0o664) alone would yield 0o664
+    # and the fchmod that carries the mode across would go unexercised.
+    old_umask = os.umask(0o022)
+    try:
+        path = tmp_path / "profile.yaml"
+        CompanyProfile(name="Before").save_to_yaml(path)
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600, "fresh profile should be private"
+        os.chmod(path, 0o664)
 
-    CompanyProfile(name="After").save_to_yaml(path)
+        CompanyProfile(name="After").save_to_yaml(path)
 
-    assert stat.S_IMODE(path.stat().st_mode) == 0o664
-    assert CompanyProfile.load_from_yaml(path).name == "After"
-    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
+        assert stat.S_IMODE(path.stat().st_mode) == 0o664
+        assert CompanyProfile.load_from_yaml(path).name == "After"
+        assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
+    finally:
+        os.umask(old_umask)
+
+
+def test_save_to_yaml_through_symlink_keeps_link_and_target_mode(tmp_path: Path):
+    """A symlinked profile path writes the target and never uses the link's 0777."""
+    import os
+    import stat
+
+    target = tmp_path / "volume" / "profile.yaml"
+    target.parent.mkdir()
+    CompanyProfile(name="Before").save_to_yaml(target)
+    link = tmp_path / "profile.yaml"
+    link.symlink_to(target)
+
+    CompanyProfile(name="After").save_to_yaml(link)
+
+    assert link.is_symlink(), "the symlink must survive the save"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert CompanyProfile.load_from_yaml(link).name == "After"
+    assert [p.name for p in target.parent.iterdir()] == ["profile.yaml"]
+    assert not os.access(target, os.W_OK) or stat.S_IMODE(target.stat().st_mode) != 0o777
 
 
 def test_concurrent_saves_do_not_break_each_other(tmp_path: Path):

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -107,3 +107,31 @@ def test_prompt_block_includes_financials():
     block = profile.to_prompt_block()
     assert "300,000" in block
     assert "8.0 months" in block
+
+
+def test_save_to_yaml_is_atomic(tmp_path: Path, monkeypatch):
+    """A failure mid-dump must leave the previous profile.yaml untouched.
+
+    The onboarding route rolls its session back on a build failure on the
+    assumption that the on-disk profile every other subsystem loads survived.
+    A plain open(path, "w") truncates before yaml.dump writes a byte.
+    """
+    import yaml
+
+    path = tmp_path / "profile.yaml"
+    CompanyProfile(name="Before").save_to_yaml(path)
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(yaml, "dump", boom)
+    try:
+        CompanyProfile(name="After").save_to_yaml(path)
+    except OSError:
+        pass
+    else:  # pragma: no cover - the monkeypatch must propagate
+        raise AssertionError("save_to_yaml swallowed the failure")
+    monkeypatch.undo()
+
+    assert CompanyProfile.load_from_yaml(path).name == "Before"
+    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"], "temp file left behind"

--- a/packages/core/tests/unit/test_company_profile.py
+++ b/packages/core/tests/unit/test_company_profile.py
@@ -137,19 +137,48 @@ def test_save_to_yaml_is_atomic(tmp_path: Path, monkeypatch):
     assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"], "temp file left behind"
 
 
-def test_save_to_yaml_preserves_mode_and_sweeps_stale_temps(tmp_path: Path):
-    """Rename creates a new inode; an operator's chmod must survive it."""
+def test_save_to_yaml_preserves_mode(tmp_path: Path):
+    """Rename creates a new inode; an operator's chmod must survive it.
+
+    0o664 rather than 0o600 on purpose: a fresh profile is already created
+    0o600, and 0o600 is umask-invariant, so it would exercise neither the
+    stat nor the fchmod that carry the mode across.
+    """
     import os
     import stat
 
     path = tmp_path / "profile.yaml"
     CompanyProfile(name="Before").save_to_yaml(path)
-    os.chmod(path, 0o600)
-    stale = tmp_path / ".tmp-1-deadbeef-profile.yaml"
-    stale.write_text("leftover from a crash", encoding="utf-8")
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600, "fresh profile should be private"
+    os.chmod(path, 0o664)
 
     CompanyProfile(name="After").save_to_yaml(path)
 
-    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.stat().st_mode) == 0o664
     assert CompanyProfile.load_from_yaml(path).name == "After"
+    assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]
+
+
+def test_concurrent_saves_do_not_break_each_other(tmp_path: Path):
+    """Two writers on one path must both succeed (last writer wins)."""
+    import threading
+
+    path = tmp_path / "profile.yaml"
+    errors: list[BaseException] = []
+
+    def _worker(name: str) -> None:
+        try:
+            for _ in range(40):
+                CompanyProfile(name=name).save_to_yaml(path)
+        except BaseException as exc:  # noqa: BLE001 - collecting for the assert
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker, args=(f"w{i}",)) for i in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert CompanyProfile.load_from_yaml(path).name.startswith("w")
     assert [p.name for p in tmp_path.iterdir()] == ["profile.yaml"]

--- a/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
@@ -1,0 +1,71 @@
+"""ARR parsing in the onboarding wizard's business-model step.
+
+Regression test for a crash that aborted onboarding entirely. The ARR
+heuristic searched ``\\$?([\\d,]+)\\s*[Mm]``, whose character class matches a
+bare comma with no digits. Any business-model answer containing a comma
+followed by a word starting with M captured ``","``, which
+``.replace(",", "")`` reduced to the empty string, and ``float("")`` raised
+``ValueError`` out of ``build_profile_from_answers``. The wizard returned 500,
+the profile was never written, and every subsequent step failed.
+
+The trigger is an ordinary sentence, not a malformed one — see the parametrised
+cases below.
+"""
+from __future__ import annotations
+
+import pytest
+
+from openexecutive.onboarding.wizard import build_profile_from_answers
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Consultoría estratégica, marketing y operaciones",
+        "Servicios profesionales, mantenimiento de sistemas",
+        "Vendemos software B2B, modelo de suscripción",
+        "We sell software, mostly to mid-market teams",
+        "Design and build, maintenance included",
+    ],
+)
+def test_comma_before_m_word_does_not_crash(text: str) -> None:
+    """A comma followed by an m-word must not be read as a magnitude."""
+    profile = build_profile_from_answers({"business_model": text})
+
+    assert profile["target_customer"]["profile"] == text
+    assert "annual_revenue_arr" not in profile
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("We do $2M in ARR", 2_000_000.0),
+        ("Roughly 12M annually", 12_000_000.0),
+        ("ARR is $1,500M across all lines", 1_500_000_000.0),
+    ],
+)
+def test_magnitude_still_parses(text: str, expected: float) -> None:
+    """A real magnitude is still picked up after the narrowing."""
+    profile = build_profile_from_answers({"business_model": text})
+
+    assert profile["annual_revenue_arr"] == expected
+
+
+def test_digits_before_an_m_word_are_not_a_magnitude() -> None:
+    """The word boundary keeps "300 clients, marketing" from meaning $300M.
+
+    Without it the capture starts at a real digit, so the crash guard alone
+    would not help — it would silently record a fabricated ARR instead.
+    """
+    profile = build_profile_from_answers(
+        {"business_model": "We have 300 clients, marketing is word of mouth"}
+    )
+
+    assert "annual_revenue_arr" not in profile
+
+
+def test_no_magnitude_leaves_the_field_unset() -> None:
+    profile = build_profile_from_answers({"business_model": "A boutique consultancy"})
+
+    assert "annual_revenue_arr" not in profile
+    assert profile["target_customer"]["pain_points"] == []

--- a/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
@@ -120,3 +120,19 @@ def test_long_whitespace_run_is_linear_time() -> None:
 
     assert "annual_revenue_arr" not in profile
     assert "burn_rate_monthly" not in profile["financials"]
+
+
+def test_long_digit_run_without_commas_is_linear_time() -> None:
+    """Pure digits hit the runway and headcount parsers, not only ARR/burn.
+
+    `(\\d+)\\s*month` without a lookbehind was quadratic (750ms at 10k),
+    and int() on a 5000-digit headcount raises at Python's digit limit.
+    """
+    text = "9" * 200_000
+    profile = build_profile_from_answers(
+        {"business_model": text, "financials": text, "headcount_and_founding": text}
+    )
+
+    assert "annual_revenue_arr" not in profile
+    assert profile["financials"] == {}
+    assert profile["headcount"] == 999_999_999

--- a/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
@@ -106,3 +106,17 @@ def test_long_digit_run_is_linear_time() -> None:
 
     assert "annual_revenue_arr" not in profile
     assert "burn_rate_monthly" not in profile["financials"]
+
+
+def test_long_whitespace_run_is_linear_time() -> None:
+    """A digit followed by a long space run must not go quadratic either.
+
+    The burn-rate pattern once had `\\s*[Kk]?\\s*`; with the K absent the two
+    `\\s*` could split the run every possible way (400ms at 10k chars, 6s at
+    40k). Sized past the API's answer bound so it does not depend on it.
+    """
+    text = "1" + " " * 200_000
+    profile = build_profile_from_answers({"business_model": text, "financials": text})
+
+    assert "annual_revenue_arr" not in profile
+    assert "burn_rate_monthly" not in profile["financials"]

--- a/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
@@ -26,6 +26,8 @@ from openexecutive.onboarding.wizard import build_profile_from_answers
         "Vendemos software B2B, modelo de suscripción",
         "We sell software, mostly to mid-market teams",
         "Design and build, maintenance included",
+        # The exact answer from issue #84.
+        "IT, marketing and video agency",
     ],
 )
 def test_comma_before_m_word_does_not_crash(text: str) -> None:
@@ -42,6 +44,11 @@ def test_comma_before_m_word_does_not_crash(text: str) -> None:
         ("We do $2M in ARR", 2_000_000.0),
         ("Roughly 12M annually", 12_000_000.0),
         ("ARR is $1,500M across all lines", 1_500_000_000.0),
+        # Phrasings the bare `[Mm]\b` narrowing silently dropped.
+        ("roughly 50 million in revenue", 50_000_000.0),
+        ("About 3 Million ARR", 3_000_000.0),
+        ("$50MM ARR last year", 50_000_000.0),
+        ("we closed the year at 7mm", 7_000_000.0),
     ],
 )
 def test_magnitude_still_parses(text: str, expected: float) -> None:
@@ -60,6 +67,21 @@ def test_digits_before_an_m_word_are_not_a_magnitude() -> None:
     profile = build_profile_from_answers(
         {"business_model": "We have 300 clients, marketing is word of mouth"}
     )
+
+    assert "annual_revenue_arr" not in profile
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "$5 minimum order, mostly SMBs",
+        "We have 300 clients, marketing is word of mouth",
+        "12 major accounts and growing",
+    ],
+)
+def test_digits_before_a_non_magnitude_m_word_are_ignored(text: str) -> None:
+    """The word boundary must hold across the whole alternation."""
+    profile = build_profile_from_answers({"business_model": text})
 
     assert "annual_revenue_arr" not in profile
 

--- a/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_arr_parse.py
@@ -91,3 +91,18 @@ def test_no_magnitude_leaves_the_field_unset() -> None:
 
     assert "annual_revenue_arr" not in profile
     assert profile["target_customer"]["pain_points"] == []
+
+
+def test_long_digit_run_is_linear_time() -> None:
+    """A "1,1,1,…" run with no magnitude after it must not go quadratic.
+
+    Every digit in the run used to be a candidate match start, so a 32k-char
+    answer took ~10s and a 320k one ~20 minutes on the event loop. With the
+    lookbehind only the run's first digit is a candidate. If this regresses
+    the test does not fail, it hangs — which is the point.
+    """
+    text = "1," * 100_000
+    profile = build_profile_from_answers({"business_model": text, "financials": text})
+
+    assert "annual_revenue_arr" not in profile
+    assert "burn_rate_monthly" not in profile["financials"]

--- a/packages/core/tests/unit/test_onboarding_wizard_financials_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_financials_parse.py
@@ -1,0 +1,49 @@
+"""Burn-rate parsing in the onboarding wizard's financials step.
+
+Sibling of the ARR regression in ``test_onboarding_wizard_arr_parse.py``:
+the burn-rate heuristic used the same ``[\\d,]+`` character class, so a bare
+comma before "monthly", "/month", "per month" or "burn" captured ``","`` and
+crashed ``build_profile_from_answers`` on ``float("")``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from openexecutive.onboarding.wizard import build_profile_from_answers
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Runway is fine, monthly costs are low",
+        "We are profitable, burn is zero",
+        "12 months runway, monthly burn 100k",
+    ],
+)
+def test_comma_before_burn_keyword_does_not_crash(text: str) -> None:
+    profile = build_profile_from_answers({"financials": text})
+
+    assert "burn_rate_monthly" not in profile["financials"]
+
+
+def test_comma_case_still_records_runway() -> None:
+    profile = build_profile_from_answers(
+        {"financials": "12 months runway, monthly burn 100k"}
+    )
+
+    assert profile["financials"]["runway_months"] == 12.0
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("burn 50k monthly", 50_000.0),
+        ("$120,000 per month, 18 months runway", 120_000.0),
+        ("We spend 30K/month", 30_000.0),
+        ("about 2,500 monthly burn", 2_500.0),
+    ],
+)
+def test_burn_rate_still_parses(text: str, expected: float) -> None:
+    profile = build_profile_from_answers({"financials": text})
+
+    assert profile["financials"]["burn_rate_monthly"] == expected

--- a/packages/core/tests/unit/test_onboarding_wizard_financials_parse.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_financials_parse.py
@@ -17,7 +17,6 @@ from openexecutive.onboarding.wizard import build_profile_from_answers
     [
         "Runway is fine, monthly costs are low",
         "We are profitable, burn is zero",
-        "12 months runway, monthly burn 100k",
     ],
 )
 def test_comma_before_burn_keyword_does_not_crash(text: str) -> None:
@@ -27,6 +26,11 @@ def test_comma_before_burn_keyword_does_not_crash(text: str) -> None:
 
 
 def test_comma_case_still_records_runway() -> None:
+    """Used to crash on the bare comma before "monthly".
+
+    The burn figure here follows its keyword, which the magnitude-first
+    heuristic does not read; this test only pins the crash and the runway.
+    """
     profile = build_profile_from_answers(
         {"financials": "12 months runway, monthly burn 100k"}
     )

--- a/packages/core/tests/unit/test_onboarding_wizard_route.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_route.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from openexecutive.api.models import ONBOARD_ANSWER_MAX_CHARS
 from openexecutive.api.routes import onboarding as route
 from openexecutive.onboarding import profile_builder
 from openexecutive.onboarding.wizard import TOTAL_STEPS
@@ -54,7 +55,7 @@ def test_builder_failure_on_final_answer_is_retryable(
 
     resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": "final"})
     assert resp.status_code == 422
-    assert "rephrase" in resp.json()["detail"]
+    assert "rephrase" in resp.json()["detail"].lower()
 
     # The session was rolled back to the last step, not stuck at completed.
     status = client.get(f"/onboard/status/{session_id}").json()
@@ -99,3 +100,26 @@ def test_issue_84_answer_completes_through_the_real_builder(
 
     assert resp.json()["completed"] is True
     assert (tmp_path / "profile.yaml").exists()
+
+
+def test_oversized_answer_is_rejected_before_parsing(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = False
+
+    def _never(state):  # type: ignore[no-untyped-def]
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(profile_builder, "build_and_save_profile", _never)
+    session_id = client.get("/onboard/start").json()["session_id"]
+
+    too_long = "x" * (ONBOARD_ANSWER_MAX_CHARS + 1)
+    resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": too_long})
+    assert resp.status_code == 422
+    assert route._wizard_sessions[session_id].current_step == 0
+
+    just_fits = "x" * ONBOARD_ANSWER_MAX_CHARS
+    resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": just_fits})
+    assert resp.status_code == 200
+    assert called is False

--- a/packages/core/tests/unit/test_onboarding_wizard_route.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_route.py
@@ -1,0 +1,101 @@
+"""HTTP-level tests for the company-onboarding wizard's final step.
+
+Regression for issue #84's second half: ``/onboard/answer`` used to commit the
+final answer (``completed=True``) *before* building the profile. When the
+build raised, the client got a 500 and every retry hit "Onboarding already
+completed" — the only way out was to restart onboarding from scratch.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openexecutive.api.routes import onboarding as route
+from openexecutive.onboarding import profile_builder
+from openexecutive.onboarding.wizard import TOTAL_STEPS
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    async def _no_research(session_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(route, "_fire_post_onboarding_research", _no_research)
+    monkeypatch.setattr(route, "_wizard_sessions", {})
+    monkeypatch.setattr(route, "_onboarding_research_fired", set())
+    app = FastAPI()
+    app.include_router(route.router)
+    return TestClient(app)
+
+
+def _answer_all_but_last(client: TestClient) -> str:
+    session_id = client.get("/onboard/start").json()["session_id"]
+    for _ in range(TOTAL_STEPS - 1):
+        resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": "x"})
+        assert resp.status_code == 200
+        assert resp.json()["completed"] is False
+    return session_id
+
+
+def test_builder_failure_on_final_answer_is_retryable(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def _boom(state):  # type: ignore[no-untyped-def]
+        calls.append("boom")
+        raise ValueError("could not convert string to float: ''")
+
+    monkeypatch.setattr(profile_builder, "build_and_save_profile", _boom)
+    session_id = _answer_all_but_last(client)
+
+    resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": "final"})
+    assert resp.status_code == 422
+    assert "rephrase" in resp.json()["detail"]
+
+    # The session was rolled back to the last step, not stuck at completed.
+    status = client.get(f"/onboard/status/{session_id}").json()
+    assert status["completed"] is False
+    assert status["current_step"] == TOTAL_STEPS - 1
+
+    # A retry with a working builder completes normally...
+    def _ok(state):  # type: ignore[no-untyped-def]
+        calls.append("ok")
+
+    monkeypatch.setattr(profile_builder, "build_and_save_profile", _ok)
+    resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": "final"})
+    assert resp.status_code == 200
+    assert resp.json()["completed"] is True
+    assert calls == ["boom", "ok"]
+
+    # ...and only then does the session refuse further answers.
+    resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": "again"})
+    assert resp.status_code == 400
+
+
+def test_issue_84_answer_completes_through_the_real_builder(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: the reporter's exact business-model answer finishes onboarding."""
+    real_build = profile_builder.build_and_save_profile
+
+    def _build_to_tmp(state):  # type: ignore[no-untyped-def]
+        return real_build(state, profile_path=tmp_path / "profile.yaml")
+
+    monkeypatch.setattr(profile_builder, "build_and_save_profile", _build_to_tmp)
+    monkeypatch.setattr(profile_builder, "_save_wizard_people", lambda answers: None)
+
+    session_id = client.get("/onboard/start").json()["session_id"]
+    answers = {"business_model": "IT, marketing and video agency"}
+    for step in range(TOTAL_STEPS):
+        from openexecutive.onboarding.wizard import WIZARD_STEPS
+
+        answer = answers.get(WIZARD_STEPS[step]["field"], "x")
+        resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": answer})
+        assert resp.status_code == 200, resp.json()
+
+    assert resp.json()["completed"] is True
+    assert (tmp_path / "profile.yaml").exists()

--- a/packages/core/tests/unit/test_onboarding_wizard_route.py
+++ b/packages/core/tests/unit/test_onboarding_wizard_route.py
@@ -114,10 +114,14 @@ def test_oversized_answer_is_rejected_before_parsing(
     monkeypatch.setattr(profile_builder, "build_and_save_profile", _never)
     session_id = client.get("/onboard/start").json()["session_id"]
 
-    too_long = "x" * (ONBOARD_ANSWER_MAX_CHARS + 1)
+    too_long = "SECRET-BURN-" + "x" * ONBOARD_ANSWER_MAX_CHARS
     resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": too_long})
     assert resp.status_code == 422
     assert route._wizard_sessions[session_id].current_step == 0
+    # The rejection must not echo the answer back (FastAPI's default
+    # validation error would include the full `input`).
+    assert "SECRET-BURN" not in resp.text
+    assert len(resp.content) < 500
 
     just_fits = "x" * ONBOARD_ANSWER_MAX_CHARS
     resp = client.post("/onboard/answer", json={"session_id": session_id, "answer": just_fits})


### PR DESCRIPTION
## What & why

Closes #84. Supersedes #56 (ninjoan's two commits are cherry-picked here with authorship intact — thank you for the diagnosis and the failing-first tests).

The onboarding wizard crashes on the final step when the business-model answer contains a comma followed by an m-word ("IT, marketing and video agency"):

```
File "openexecutive/onboarding/wizard.py", line 201, in build_profile_from_answers
ValueError: could not convert string to float: ''
```

The ARR heuristic's `[\d,]+` matches a bare comma, `.replace(",", "")` reduces it to `""`, and `float("")` raises. Three things compound it that #56 did not cover:

1. The **burn-rate regex** in the financials step has the identical defect.
2. The route commits `completed=True` **before** building the profile, so the crash returns a 500 and every retry hits "Onboarding already completed". The only way out was restarting onboarding.
3. The `\b` narrowing in #56 silently dropped "roughly 50 million" and "$50MM" (per the review on #56).

Five adversarial review passes on the fix then surfaced more, fixed in commits 2 through 6:

4. All three financials/ARR regexes were **quadratic** on hostile input and the answer field was unbounded. A 32k-char answer stalled the event loop ~10s. The burn-rate pattern had a second quadratic path through `\s*[Kk]?\s*`, and the runway pattern a third. The headcount parse could also hit Python's int digit limit. The parsers are now verified linear across every wizard field (~25 hand-built payloads plus fuzzing, worst case 6ms at the 10k bound).
5. The route's failure log and the people-store log echoed **user answers** through exception text, including the financials step the wizard promises is "stored locally only". A `Field(max_length)` rejection also echoed the whole answer back in the 422 body.
6. `save_to_yaml` truncated before writing, so a failure mid-dump destroyed the existing profile. Getting the replacement right took several rounds: a naive write-then-rename dropped the file's mode, followed symlinks at a predictable temp name, and did not fsync; a stale-temp sweep raced concurrent writers; `lstat` on a symlinked path took the link's 0777; a temp created at the destination's mode left a readable copy of the financials behind on SIGKILL; and `resolve()` raised an unexpected exception type on a symlink loop.

## How it works

- **ARR** — capture starts with a digit behind a `(?<[\d,])` lookbehind so only the first digit of a run is a match candidate; magnitude is `(?:[Mm]{1,2}|[Mm]illion)\b`. "M", "MM", "million" and "Million" parse; "$5 minimum", "300 clients, marketing" and "12 major accounts" do not. Linear: 320k chars in 20ms.
- **Burn rate and runway** — same lookbehind on both, and `\s*(?:[Kk]\s*)?` on burn so whitespace cannot be split two ways. 10k-char hostile inputs: 405ms → 0.7ms and 668ms → 0.5ms, phrasings unchanged. Headcount digits capped at nine.
- **Answer bound** — 10k chars, checked in the route with a static message so the rejection carries none of the answer. The constant's comment flags it as a safety bound, not a UX choice.
- **Route** — deep-copy the session before `process_answer` mutates it in place; on a builder failure restore the snapshot and return **422**. Logs carry the exception type only. The detail suggests restarting if an earlier answer is the problem, since the fragile parsers run on steps 3 and 7.
- **Atomic profile save** — the path is resolved first so a symlinked `COMPANY_PROFILE_PATH` writes its target and the link survives; a symlink loop falls back to the unresolved path and is replaced by a fresh private file. The temp file is created 0600 and O_EXCL via an `opener` (through `open()`, so the existing UTF-8 contract test still sees the encoding) with a random suffix so two containers on one volume cannot collide. After fsync it is widened to the destination's existing mode (never a symlink's) and renamed over it; the directory is then fsynced. A crash leftover is therefore a 0600 file, never a readable copy. No sweep of leftovers: one cannot be told apart from another process's in-flight file. Fresh profiles are created 0600.
- **People store** — `_save_wizard_people` logs the exception type only; the traceback carried org-chart names, emails and handles.

Regression tests: 41 across four files. The first-cut set fails 16 of 28 on `main`. Additions cover 100k and 200k-char hostile runs of three shapes (they hang rather than fail on regression), the route-level length bound including that the 422 body does not echo the answer, an atomic-save test that fails the dump and checks the old profile survives, mode preservation using a non-default mode so `fchmod` is exercised, a symlinked path keeping its link and a 0640 target mode, a self-referential symlink replaced cleanly, and a six-thread concurrent-save test.

Deliberately left alone:

- "1M users" still records a fabricated $1M ARR, because that M legitimately ends a word. Fixing it means teaching the heuristic revenue context.
- The wizard session dict has no TTL or cap. Pre-existing and unrelated to this crash.
- No per-session retry cap on the final step. With bounded input and linear parsers a retry costs well under a millisecond.
- `_fire_post_onboarding_research` persists `str(exc)[:200]` to the workflow run. That is the research workflow's own error, a different data path from the wizard answers.
- `chown` is not carried across the rename; only the mode is. The service runs as one user.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] Tests added/updated for new behavior (`pytest packages/core/tests/unit/`) — 2875 passed, 1 skipped
- [x] `ruff check` and `mypy` pass (`make lint`)
- [x] UI builds if touched — not touched
- [x] Eval scenarios added for a new agent or prompt change — not applicable
- [x] Architecture docs updated if a documented topic changed — `architecture-facts.yaml` line 1560 describes onboarding completion as "when the wizard finishes (build_and_save_profile fires)", which is still accurate; no endpoint shape changed, only a new 422 error path
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

- The rollback relies on `process_answer` mutating the stored `WizardState` in place; the explicit re-store at the end of the route is kept for clarity, not correctness.
- `save_to_yaml` is shared with the company-profile editor route, so the atomic write benefits that path too. Fresh profiles are now created 0600 rather than the umask default; if a second uid needs to read the file, chmod it once and the mode is preserved thereafter.
- `ruff format` was not run, matching #56's reasoning: `make lint` does not invoke it and `wizard.py` on `main` already reports "would be reformatted".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHsrFk1YtpBw1tPNuTeod7