### PR TITLE
fix: correct trustHost auto-detection instead of overriding it

### DIFF
--- a/packages/ui/src/auth.ts
+++ b/packages/ui/src/auth.ts
@@ -94,6 +94,32 @@ function auditAuth(
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
+  // @auth/core auto-detects trustHost via `AUTH_URL ?? AUTH_TRUST_HOST ??
+  // VERCEL ?? CF_PAGES ?? NODE_ENV !== "production"` — a chain of `??`
+  // (nullish coalescing). This repo's own local-dev default sets AUTH_URL
+  // to an EMPTY STRING, which is present-but-not-nullish, so it
+  // short-circuits that chain to `false` *before* AUTH_TRUST_HOST or the
+  // NODE_ENV fallback are ever consulted — exactly the documented local-dev
+  // config (AUTH_TRUST_HOST=true, AUTH_URL blank) breaks sign-in.
+  //
+  // Reimplemented below with an emptiness test instead of `??`, so a blank
+  // AUTH_URL can no longer mask AUTH_TRUST_HOST. Deliberately NOT a
+  // hardcoded `true`: that would trust the host on any real deployment
+  // that leaves AUTH_URL blank, letting a spoofed X-Forwarded-Host drive
+  // the OAuth callback/redirect origin. VERCEL/CF_PAGES/NODE_ENV are also
+  // deliberately dropped, not just reordered: this app doesn't target
+  // those platforms, and a literal `process.env.NODE_ENV` check gets
+  // folded to a build-time constant by Next.js's bundler (verified against
+  // the compiled output — even reading it off an intermediate variable
+  // didn't survive Turbopack's dead-code elimination), so it can't
+  // actually reflect the container's runtime NODE_ENV the way @auth/core's
+  // own dynamic property access does. This repo's documented local-dev
+  // setup already sets AUTH_TRUST_HOST=true explicitly and never relied on
+  // that fallback anyway. A deployment that sets neither AUTH_URL nor
+  // AUTH_TRUST_HOST gets `false` here — fail-closed, matching intent.
+  trustHost:
+    Boolean(process.env.AUTH_URL?.trim()) ||
+    process.env.AUTH_TRUST_HOST?.trim().toLowerCase() === "true",
   providers: [Google],
   // 24h JWT TTL. Defence in depth alongside the `authorized` re-check
   // below — a session that somehow drifts out of sync with the roster


### PR DESCRIPTION
## What & why

Follow-up to the auth discussion on #81, split into its own PR as requested there. This supersedes what I originally proposed (`trustHost: true` hardcoded) with a properly-diagnosed and reviewed fix — the earlier version had a real problem, explained below.

**Repro** (unchanged from #81): `make docker`, with this repo's own documented local-dev `.env` (`AUTH_TRUST_HOST=true`, `AUTH_URL=` left blank — exactly what `.env.example` and `docs/auth.md` say to do). Sign-in fails with `[auth][error] UntrustedHost: Host must be trusted`.

**Corrected root cause**: my first explanation on #81 (Next.js Edge runtime can't see Docker-Compose-injected env vars) was wrong — I said so on that thread, but for the record here too. The actual cause: `@auth/core`'s own `trustHost` auto-detection is a `??` (nullish-coalescing) chain — `AUTH_URL ?? AUTH_TRUST_HOST ?? VERCEL ?? CF_PAGES ?? NODE_ENV !== "production"`. This repo's local-dev default sets `AUTH_URL` to an **empty string**, which is present-but-not-nullish, so it short-circuits that chain to `false` *before* `AUTH_TRUST_HOST` is ever read. Confirmed by extracting and executing the actual `@auth/core@0.41.3` source.

**Why not just hardcode `trustHost: true`** (what I tried first): that removes the only fail-closed guard `@auth/core` has. The *original* code (no `trustHost` key at all) was already fail-closed in production, via the `NODE_ENV !== "production"` fallback — any deployment with `NODE_ENV=production` and no `AUTH_URL`/`AUTH_TRUST_HOST` set correctly got `UntrustedHost`. Hardcoding `true` unconditionally would make every non-Fly self-hosted deployment (bare VPS behind nginx, Render, Railway, k8s — anything using `docker/Dockerfile.ui` directly) trust a spoofed `X-Forwarded-Host`, opening a host-header-injection path into the OAuth callback/redirect origin. I caught this via adversarial review before it went anywhere.

## How it works

Reimplement the same three real signals (`AUTH_URL`, `AUTH_TRUST_HOST`, explicit — `VERCEL`/`CF_PAGES` dropped since this app doesn't target either) with a real emptiness check (`.trim()`) instead of `??`, so a blank `AUTH_URL` can no longer mask `AUTH_TRUST_HOST`. Production stays fail-closed exactly as before when neither is set.

One more wrinkle worth documenting: I initially tried keeping a `NODE_ENV !== "production"` fallback too (matching `@auth/core`'s full chain), even reading it off an intermediate variable the way `@auth/core`'s own source does internally to avoid bundler folding. It didn't work — I inspected the actual compiled Turbopack output and the whole term got dead-code-eliminated to a build-time constant anyway, since (unlike `@auth/core`'s pre-built package) this file is part of the app's own source that Next.js's bundler processes end-to-end. Dropped it rather than ship something that looks like a runtime check but isn't. Not a loss in practice — the documented local-dev setup already sets `AUTH_TRUST_HOST=true` explicitly and never relied on that fallback.

Verified against 7 env-var combinations by direct execution (local dev, production with a real URL, production with everything blank, production with explicit trust, whitespace-only `AUTH_URL`, case-variant `AUTH_TRUST_HOST`, and the fully-undocumented bare case) — all match intent. Also verified `npm run build` succeeds and inspected the compiled bundle to confirm the shipped expression matches source exactly.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [x] `ruff check` and `mypy` pass — n/a, no Python changed
- [x] UI builds (`npm run build` passes clean)
- [ ] Tests — `packages/ui` has no test runner configured; verified via direct execution of the exact expression against the scenario matrix above instead
- [ ] Eval scenarios — n/a, no agent/prompt change
- [ ] Architecture docs — n/a, no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Scope is deliberately just `packages/ui/src/auth.ts` — I also tried removing `AUTH_TRUST_HOST` from `.env.example`/`docs/auth.md`/`docs/deployment.md`/`docker-compose.yml`/`fly.ui.qa.toml`/`scripts/fly-secrets.sh.example` (reasoning it'd become vestigial once hardcoded), but with this corrected approach `AUTH_TRUST_HOST` is still genuinely read and still needs to be exactly as documented — those files are untouched.