### PR TITLE
fix(ui): show an error for oversized chat attachments

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --experimental-strip-types --test scripts/*.test.mjs"
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.1.0",

--- a/packages/ui/scripts/file-attachments.test.mjs
+++ b/packages/ui/scripts/file-attachments.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAX_BYTES_PER_FILE,
+  MAX_FILES_PER_TURN,
+  mergePickedFiles,
+} from "../src/lib/file-attachments.ts";
+
+test("rejects oversized files with an actionable message", () => {
+  const oversized = { name: "quarterly-report.pdf", size: MAX_BYTES_PER_FILE + 1 };
+
+  const result = mergePickedFiles([], [oversized]);
+
+  assert.deepEqual(result.files, []);
+  assert.deepEqual(result.rejected, ["quarterly-report.pdf is too large (max 20 MB)"]);
+});
+
+test("keeps valid files while rejecting oversized files from the same pick", () => {
+  const valid = { name: "notes.txt", size: 100 };
+  const oversized = { name: "archive.zip", size: MAX_BYTES_PER_FILE + 1 };
+
+  const result = mergePickedFiles([], [valid, oversized]);
+
+  assert.deepEqual(result.files, [valid]);
+  assert.deepEqual(result.rejected, ["archive.zip is too large (max 20 MB)"]);
+});
+
+test("preserves the existing file-count cap and de-duplicates files", () => {
+  const current = Array.from({ length: MAX_FILES_PER_TURN }, (_, i) => ({
+    name: `file-${i}.txt`,
+    size: i + 1,
+  }));
+
+  const result = mergePickedFiles(current, [current[0], { name: "extra.txt", size: 10 }]);
+
+  assert.deepEqual(result.files, current);
+  assert.deepEqual(result.rejected, []);
+});

--- a/packages/ui/src/components/Chat.tsx
+++ b/packages/ui/src/components/Chat.tsx
@@ -8,6 +8,10 @@ import CommitteePhaseIndicator from "./CommitteePhaseIndicator";
 import Icon from "./Icon";
 import InfoTip from "./InfoTip";
 import {
+  MAX_FILES_PER_TURN,
+  mergePickedFiles,
+} from "@/lib/file-attachments";
+import {
   ActionTaken,
   ChatMessage,
   CommitteePhase,
@@ -68,16 +72,11 @@ export default function Chat({ onDebugEvent, initialMessages, initialSessionId, 
   const [subtitle, setSubtitle] = useState<string>(FALLBACK_SUBTITLE);
   const [isLoadingPrompts, setIsLoadingPrompts] = useState(true);
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const [fileError, setFileError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const adoptedSessionIdRef = useRef<string | undefined>(initialSessionId);
-
-  // Mirror the backend's `_MAX_FILES_PER_TURN` / `_MAX_BYTES_PER_FILE`. Kept
-  // in sync manually; a mismatch only costs an extra round-trip + the user
-  // sees the server's 413 message, so no correctness risk.
-  const MAX_FILES_PER_TURN = 5;
-  const MAX_BYTES_PER_FILE = 20 * 1024 * 1024;
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -141,6 +140,7 @@ export default function Chat({ onDebugEvent, initialMessages, initialSessionId, 
 
     setInput("");
     setPendingFiles([]);
+    setFileError(null);
     setMessages((prev) => [...prev, { role: "user", content: userBubbleContent }]);
     setIsLoading(true);
     setStreamingContent("");
@@ -238,16 +238,9 @@ export default function Chat({ onDebugEvent, initialMessages, initialSessionId, 
     // Reset the input so re-picking the same file re-fires onChange.
     e.target.value = "";
     if (picked.length === 0) return;
-    setPendingFiles((prev) => {
-      const merged = [...prev];
-      for (const f of picked) {
-        if (merged.length >= MAX_FILES_PER_TURN) break;
-        if (f.size > MAX_BYTES_PER_FILE) continue;
-        if (merged.some((m) => m.name === f.name && m.size === f.size)) continue;
-        merged.push(f);
-      }
-      return merged;
-    });
+    const result = mergePickedFiles(pendingFiles, picked);
+    setPendingFiles(result.files);
+    setFileError(result.rejected.length > 0 ? result.rejected.join(" ") : null);
   }
 
   function removePendingFile(index: number) {
@@ -384,6 +377,11 @@ export default function Chat({ onDebugEvent, initialMessages, initialSessionId, 
                 </div>
               ))}
             </div>
+          )}
+          {fileError && (
+            <p className="text-sm text-red-400 mb-2" role="alert">
+              {fileError}
+            </p>
           )}
           <div className="relative flex items-end gap-2 sm:gap-3 bg-surface-overlay/50 border border-line-strong rounded-2xl px-3 sm:px-4 py-3 focus-within:border-fg-muted transition-colors">
             <input

--- a/packages/ui/src/lib/file-attachments.ts
+++ b/packages/ui/src/lib/file-attachments.ts
@@ -1,0 +1,35 @@
+export const MAX_FILES_PER_TURN = 5;
+export const MAX_BYTES_PER_FILE = 20 * 1024 * 1024;
+
+export interface FileSelection<T> {
+  files: T[];
+  rejected: string[];
+}
+
+type AttachmentFile = {
+  name: string;
+  size: number;
+};
+
+export function mergePickedFiles<T extends AttachmentFile>(
+  current: readonly T[],
+  picked: readonly T[],
+): FileSelection<T> {
+  const files = [...current];
+  const rejected: string[] = [];
+
+  for (const file of picked) {
+    if (file.size > MAX_BYTES_PER_FILE) {
+      const maxSizeMb = MAX_BYTES_PER_FILE / (1024 * 1024);
+      rejected.push(`${file.name} is too large (max ${maxSizeMb} MB)`);
+      continue;
+    }
+    if (files.length >= MAX_FILES_PER_TURN) break;
+    if (files.some((existing) => existing.name === file.name && existing.size === file.size)) {
+      continue;
+    }
+    files.push(file);
+  }
+
+  return { files, rejected };
+}


### PR DESCRIPTION
## Summary / Problem

Fixes #99. Oversized files selected in the chat attachment picker were silently ignored, leaving users without feedback about why the attachment was missing.

## Changes

- Extract the chat attachment size and count rules into a small reusable helper.
- Reject files over 20 MB with an actionable inline alert that includes the file name and size limit.
- Preserve the existing five-file cap and duplicate-file detection.
- Add focused behavior tests for oversized files, mixed valid/oversized selections, and the existing cap/deduplication rules.

## Tests

- `npm test` (3 tests)
- `npx tsc --noEmit`
- `npm run build`
- Node 22 isolated pre-PR validation with the same install, test, typecheck, and build commands

## Compatibility / Known limitations

The existing attachment count limit and duplicate detection are unchanged. Files over 20 MB are rejected before upload and can be retried after the user selects a smaller file.

## Issue link

https://github.com/SenteLabsAI/OpenExecutive/issues/99
