### PR TITLE
Run the UI unit tests in CI; restore the backend-sync comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,11 @@ jobs:
       - name: Type check
         run: cd packages/ui && npx tsc --noEmit
 
+      # node:test suites added in #100. Runs on the same Node 22 the job
+      # already uses (--experimental-strip-types needs 22.6+).
+      - name: Run UI unit tests
+        run: cd packages/ui && npm test
+
       - name: Build
         run: cd packages/ui && npm run build
         env:

--- a/packages/ui/src/lib/file-attachments.ts
+++ b/packages/ui/src/lib/file-attachments.ts
@@ -1,3 +1,6 @@
+// Mirror the backend's `_MAX_FILES_PER_TURN` / `_MAX_BYTES_PER_FILE`. Kept
+// in sync manually; a mismatch only costs an extra round-trip + the user
+// sees the server's 413 message, so no correctness risk.
 export const MAX_FILES_PER_TURN = 5;
 export const MAX_BYTES_PER_FILE = 20 * 1024 * 1024;
 


### PR DESCRIPTION
## What & why

Maintainer follow-up to #100, which added the repo's first UI test infrastructure (`npm test` running node:test suites) but didn't wire it into CI — the suite existed with nothing running it. It also dropped a load-bearing comment when the attachment limits moved into `src/lib/file-attachments.ts`.

## How it works

- **`.github/workflows/ci.yml`**: the ui job runs `npm test` between typecheck and build. Same Node 22 the job already uses (`--experimental-strip-types` needs 22.6+; setup-node "22" satisfies it).
- **`packages/ui/src/lib/file-attachments.ts`**: restores the comment noting the constants mirror the backend's `_MAX_FILES_PER_TURN` / `_MAX_BYTES_PER_FILE` and are kept in sync manually.

## Checklist

- [x] Working implementation — no stubs or TODO placeholders
- [ ] Tests added/updated for new behavior — this wires existing tests into CI; no behavior change
- [x] `ruff check` and `mypy` pass (`make lint`) — Python untouched
- [x] UI builds if touched (`cd packages/ui && npx tsc --noEmit`) — tsc clean, npm test 3/3
- [ ] Eval scenarios added for a new agent or prompt change — none
- [ ] Architecture docs updated if a documented topic changed — no documented topic changed
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

Two other observations from reviewing #100, deliberately not included here since they change behavior: over-cap file drops (6th file onward) are still silent — only oversized files get the new error — and the file-pick handler now reads `pendingFiles` directly instead of using a functional state update. Both are candidates for a future tweak if they bother anyone in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTDH86WbrpdkvMR3w74PXD)_