### PR TITLE
docs: observability, reading the audit log and scheduled sends from outside the process

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The deployed UI is gated behind Google sign-in with an email allow-list, and the
 
 ### Observability
 
-Every turn, specialist consult, tool call, model call and queued outbound send is recorded in `episodic_memory.db`. See [docs/observability.md](docs/observability.md) for what is recorded, how to read it from outside the process, and how to read the cost figures.
+Every turn, specialist consult, tool call, model call and queued outbound send is recorded in `episodic_memory.db`. See [docs/observability.md](docs/observability.md) for what is recorded, how to read it from outside the process, and how to read the cost figures, or watch it live with [ClawMetry](https://clawmetry.com/runtimes/openexecutive).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ health-check timing, resource sizing, operations, and common failure modes.
 
 The deployed UI is gated behind Google sign-in with an email allow-list, and the public API is protected by a shared-secret header between the UI proxy and the FastAPI backend. See [docs/auth.md](docs/auth.md) for the full setup (Google Cloud Console steps, required environment variables, adding/removing users, rotating secrets, and a debugging table).
 
+### Observability
+
+Every turn, specialist consult, tool call, model call and queued outbound send is recorded in `episodic_memory.db`. See [docs/observability.md](docs/observability.md) for what is recorded, how to read it from outside the process, and how to read the cost figures.
+
 ## Configuration
 
 All settings via environment variables. Minimum required: `ANTHROPIC_API_KEY` —

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -28,6 +28,37 @@ Open it read-only so you can never lock or modify the live database:
 sqlite3 "file:packages/core/episodic_memory.db?mode=ro"
 ```
 
+## Live dashboard with ClawMetry
+
+The sections below show how to read the database yourself. If you would rather
+watch it live, [ClawMetry](https://clawmetry.com/runtimes/openexecutive) reads
+this same file read-only, with no change to Open Executive:
+
+1. Install it. On macOS or Linux:
+
+   ```sh
+   curl -fsSL https://clawmetry.com/install.sh | bash
+   ```
+
+   (Windows and desktop installers are on the
+   [ClawMetry page](https://clawmetry.com/runtimes/openexecutive).)
+
+2. Run `clawmetry`. It finds a clone under your home directory on its own. For
+   Docker, point it at the file first:
+
+   ```sh
+   export CLAWMETRY_OPENEXECUTIVE_DB=/path/to/episodic_memory.db
+   clawmetry
+   ```
+
+3. Open `http://localhost:8900` and pick OpenExecutive in the runtime switcher.
+
+You get every conversation, including the ones that started in Slack or email;
+each specialist consult as a step with its question and answer; failed tool
+calls; token usage and cost per conversation; and every send the scheduler has
+queued, with its status, so a pending message is visible before it goes out.
+The OpenExecutive integration is part of ClawMetry's paid plans.
+
 ## What is recorded
 
 | Table | What it holds |
@@ -51,7 +82,7 @@ Slack and email conversations write `audit_log` rows but no `sessions` row, so
 to list every conversation, read session ids from `audit_log`, not only from
 `sessions`.
 
-## Three questions you can answer today
+## Four questions you can answer today
 
 **What is about to be sent, and to whom?**
 
@@ -122,14 +153,3 @@ ORDER BY ts DESC;
   measured", not "free".
 - Rows written by background work (research runs, triage) may carry no
   `session_id`; research runs tag theirs with `details.run_id` instead.
-
-## Dashboards and alerts
-
-The queries above are enough for a cron job or a quick check. If you would
-rather have this as a live dashboard, [ClawMetry](https://github.com/vivekchand/clawmetry)
-reads this database directly (read-only, no code change) and shows each
-conversation with its specialist consults, tool failures, token usage and cost,
-alongside the pending, delivered and failed sends from `scheduled_actions`. It
-finds a clone under your home directory automatically; for Docker, point it at
-the file with `CLAWMETRY_OPENEXECUTIVE_DB=/path/to/episodic_memory.db`. The
-OpenExecutive integration is part of ClawMetry's paid plans.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,135 @@
+# Observability: watching a running Executive
+
+Open Executive acts on its own. It answers in Slack and email, consults
+specialists, calls tools, and its scheduler sends messages later without anyone
+in the loop. This page explains what the Executive records about all of that,
+where it lives, and how to watch it from **outside** the process, without
+touching the code or the prompts.
+
+Everything below reads the same SQLite file the API writes. Nothing here needs
+a code change, a restart, or a new dependency.
+
+## Where the record lives
+
+One SQLite file, set by `EPISODIC_DB_PATH`:
+
+| How you run it | Path |
+|---|---|
+| `make dev` | `packages/core/episodic_memory.db` (the default `./episodic_memory.db`, relative to the API's working directory) |
+| Docker (`docker/docker-compose.yml`) | `/data/episodic_memory.db` inside the `executive_data` volume |
+
+A Docker named volume is not visible from the host. To read it from outside the
+container, bind-mount `/data` to a host directory instead, or copy the file out
+with `docker compose cp api:/data/episodic_memory.db .`.
+
+Open it read-only so you can never lock or modify the live database:
+
+```sh
+sqlite3 "file:packages/core/episodic_memory.db?mode=ro"
+```
+
+## What is recorded
+
+| Table | What it holds |
+|---|---|
+| `sessions`, `chat_messages` | Web chat conversations and their transcript |
+| `audit_log` | One row per event, with `session_id`, `turn_id`, `actor`, a searchable `summary`, and structured `details_json` |
+| `scheduled_actions` | Every outbound send the Executive queued: `channel`, `channel_ref`, `run_at`, `intent_text`, `status` (`pending`, `running`, `done`, `failed`, `cancelled`) |
+
+Useful `audit_log.event_type` values:
+
+| `event_type` | Meaning |
+|---|---|
+| `chat_turn` | A user message (`actor = 'user'`) or the Executive's reply (`actor = 'executive'`) |
+| `specialist_consult` | The Executive consulted a specialist; `actor` is the specialist, `full_json` has the question and the answer |
+| `tool_invocation` | A tool call; `details_json.ok` is `false` when it failed |
+| `cache_event` | One model call, written by `audit/usage.py::log_model_usage`: `model`, `input_tokens`, `output_tokens`, cache read/write tokens, `cost_usd`, `web_search_requests`. `actor` names the source (`executive`, `specialist_research`, `research_synthesis`, `research_watchlist`, `triage`, `memory_extractor`) |
+| `integration_inbound` | A message arrived from Slack, email, Telegram, Discord or Google Chat |
+| `scheduled_action` | The scheduler delivered, deferred, dropped or failed a queued send (`details_json.phase`) |
+
+Slack and email conversations write `audit_log` rows but no `sessions` row, so
+to list every conversation, read session ids from `audit_log`, not only from
+`sessions`.
+
+## Three questions you can answer today
+
+**What is about to be sent, and to whom?**
+
+```sql
+SELECT run_at, channel, channel_ref, intent_text
+FROM scheduled_actions
+WHERE status = 'pending'
+  AND channel != '__internal__'
+ORDER BY run_at;
+```
+
+`__internal__` rows are the scheduler's own recurring jobs (department
+check-ins, monitoring scans, briefs being prepared). They never reach a
+person as written, so they are left out here.
+
+**What did each conversation cost?**
+
+```sql
+SELECT session_id,
+       SUM(json_extract(details_json, '$.input_tokens'))  AS input_tokens,
+       SUM(json_extract(details_json, '$.output_tokens')) AS output_tokens,
+       SUM(json_extract(details_json, '$.cost_usd'))      AS reported_usd
+FROM audit_log
+WHERE event_type = 'cache_event'
+GROUP BY session_id
+ORDER BY reported_usd DESC;
+```
+
+**Where did the spend come from?**
+
+```sql
+SELECT COALESCE(actor, 'unknown') AS source,
+       COUNT(*)                                            AS calls,
+       SUM(json_extract(details_json, '$.input_tokens'))  AS input_tokens,
+       SUM(json_extract(details_json, '$.output_tokens')) AS output_tokens,
+       SUM(json_extract(details_json, '$.cost_usd'))      AS reported_usd
+FROM audit_log
+WHERE event_type = 'cache_event'
+GROUP BY source
+ORDER BY input_tokens DESC;
+```
+
+**What failed?**
+
+```sql
+SELECT ts, event_type, summary
+FROM audit_log
+WHERE (event_type = 'tool_invocation' AND json_extract(details_json, '$.ok') = 0)
+   OR (event_type = 'scheduled_action' AND json_extract(details_json, '$.phase') = 'failed')
+ORDER BY ts DESC;
+```
+
+## Reading the cost figures correctly
+
+- `cost_usd` is the real charge when calls are routed through OpenRouter. On
+  the Anthropic-direct path it is `NULL`, and a dollar figure has to be worked
+  out from the token counts and the model's published price.
+- Most model calls write a `cache_event` (see the `actor` values above). One
+  path does not: the specialist consults the Executive makes during a chat
+  turn (`consult_specialist`, which runs `BaseAgent.analyze`) record no usage
+  row. Specialist calls made through `analyze_with_tools`, such as monitoring
+  research, are recorded under `specialist_research`. So a conversation's total
+  from this table is a **lower bound** whenever the Executive consulted a
+  specialist.
+- On a local model (`LOCAL_MODELS_ENABLED=true`, e.g. Ollama), each call still
+  writes a `cache_event` with the model name, but the token fields are `0`
+  unless the server reports usage on its stream. A zero there means "not
+  measured", not "free".
+- Rows written by background work (research runs, triage) may carry no
+  `session_id`; research runs tag theirs with `details.run_id` instead.
+
+## Dashboards and alerts
+
+The queries above are enough for a cron job or a quick check. If you would
+rather have this as a live dashboard, [ClawMetry](https://github.com/vivekchand/clawmetry)
+reads this database directly (read-only, no code change) and shows each
+conversation with its specialist consults, tool failures, token usage and cost,
+alongside the pending, delivered and failed sends from `scheduled_actions`. It
+finds a clone under your home directory automatically; for Docker, point it at
+the file with `CLAWMETRY_OPENEXECUTIVE_DB=/path/to/episodic_memory.db`. The
+OpenExecutive integration is part of ClawMetry's paid plans.


### PR DESCRIPTION
## What & why

Open Executive acts on its own: it answers in Slack and email, consults specialists, calls tools, and its scheduler sends messages later with no one in the loop. Almost all of that is already written down in `episodic_memory.db`, but nothing in the docs says what is recorded, where the file lives, or how to read it without touching the running API.

This PR adds `docs/observability.md` and a short "Observability" pointer in the README. It is documentation only: no code, no dependency, no behaviour change.

The page covers:

- **Where the record lives:** `EPISODIC_DB_PATH` under `make dev` and under Docker, and how to reach a named volume from the host.
- **A live dashboard:** a short section on watching all of this in [ClawMetry](https://clawmetry.com/runtimes/openexecutive) (install, run, open the dashboard), which reads the same file read-only.
- **What is recorded:** `sessions`, `chat_messages`, `audit_log` (with the `event_type` values that matter) and `scheduled_actions`.
- **Four read-only queries** anyone can run with `sqlite3`: what is about to be sent and to whom, cost per conversation, spend by source (`actor`), and what failed.
- **How to read the cost figures correctly**, including two gaps worth knowing:
  - specialist consults made during a chat turn (`consult_specialist`, which runs `BaseAgent.analyze`) write no `cache_event`, so a conversation's total is a lower bound when a specialist was consulted;
  - on a local OpenAI-compatible model, token fields are `0` unless the server streams usage, so a zero means "not measured".

## How it works

Every statement was checked against `main` at `c9c0512`, including `audit/usage.py::log_model_usage` from commit `e4ffbff` ("record every model call"), the `router.py` consult path, `providers/translator.py`'s stream accumulator and `docker/docker-compose.yml`.

The queries were run against an `episodic_memory.db` written by this repo's own storage code (`episodic.initialize_db`, `session_store`, `AuditLogger`), and against a store from a real chat turn on a local Ollama model (`qwen3:8b`, `LOCAL_MODELS_ENABLED=true`). That run is where the zero-usage note comes from: the turn consulted the CFO and CSO, and both `cache_event` rows named `qwen3:8b` with every token field `0`.

Disclosure: I maintain ClawMetry, the agent observability tool the "Live dashboard" section describes. It reads `episodic_memory.db` read-only and needs no change to this repo. Its OpenExecutive integration is part of ClawMetry's paid plans, and the section says so. Everything else on the page works with plain `sqlite3`. If you would rather keep the docs tool-neutral, I am happy to trim that section to a one-line link.

## Checklist

- [x] Working implementation, no stubs or TODO placeholders (docs only)
- [ ] Tests added/updated for new behavior (n/a: no behavior change)
- [x] `ruff check` and `mypy` pass (no Python touched)
- [ ] UI builds if touched (n/a: UI not touched)
- [ ] Eval scenarios added for a new agent or prompt change (n/a)
- [x] Architecture docs updated if a documented topic changed (no documented topic changed; this adds a new page)
- [x] No secrets, credentials, or personal data committed

## Notes for reviewers

- The specialist-consult usage gap looks like it may be unintentional: `analyze_with_tools` calls `log_model_usage`, `analyze` does not. If you would rather close it than document it, I am glad to send that change separately, and the doc line can go.
- If you prefer a different location (for example a section in `docs/deployment.md`), I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015D9pee1kCZ8NanY9bZirq4
